### PR TITLE
Add e2e tests using `acktest` and Github actions workflow

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -1,0 +1,67 @@
+name: e2e-test
+on:
+  # Allow manual trigger of e2e tests
+  workflow_dispatch:
+    inputs:
+      communityRepo:
+        description: 'Git repository for checking out the community repo'
+        required: false
+        default: 'aws-controllers-k8s/community'
+      communityRef:
+        description: 'Git ref for checking out the community repo. Default is main'
+        required: false
+        default: ''
+      testInfraRepo:
+        description: 'Git repository for checking out the test-infra repo'
+        required: false
+        default: 'aws-controllers-k8s/test-infra'
+      testInfraRef:
+        description: 'Git ref for checking out the test-infra repo. Default is main'
+        required: false
+        default: ''
+
+jobs:
+  e2e-test:
+    name: controller e2e test
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+         - ecr
+    runs-on: [aws-controllers-k8s]
+    steps:
+      - name: Set up Go 1.15
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.15
+        id: go
+
+      - name: checkout service
+        uses: actions/checkout@v2
+        with:
+          path: './src/github.com/aws-controllers-k8s/${{ matrix.service }}-controller'
+
+      - name: checkout community
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.event.inputs.communityRepo }}
+          ref: ${{ github.event.inputs.communityRef }}
+          path: './src/github.com/aws-controllers-k8s/community'
+
+      - name: checkout test-infra
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.event.inputs.testInfraRepo }}
+          ref: ${{ github.event.inputs.testInfraRef }}
+          path: './src/github.com/aws-controllers-k8s/test-infra'
+
+      - name: execute e2e tests
+        working-directory: './src/github.com/aws-controllers-k8s/community'
+        run: |
+          export AWS_ROLE_ARN=$(aws ssm get-parameter --name ACK_ROLE_ARN --query "Parameter.Value" --output text)
+          export AWS_ROLE_ARN_ALT=$(aws ssm get-parameter --name ACK_ROLE_ARN_ALT --query "Parameter.Value" --output text)
+          ./scripts/kind-build-test.sh $SERVICE
+        env:
+          SERVICE: ${{ matrix.service }}
+          GOPATH: ${{ github.workspace }}
+          PRESERVE: 'false'

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -1,0 +1,25 @@
+name: unit-test
+on:
+  # Allow manual trigger
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '**.go'
+      - Makefile
+      - go.mod
+      - go.sum
+
+jobs:
+  build:
+    name: make test
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.15'
+      - name: make test
+        run: make test

--- a/test/e2e/.gitignore
+++ b/test/e2e/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+**/bootstrap.yaml

--- a/test/e2e/__init__.py
+++ b/test/e2e/__init__.py
@@ -1,0 +1,33 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import pytest
+from typing import Dict, Any
+from pathlib import Path
+
+from acktest.resources import load_resource_file
+
+SERVICE_NAME = "ecr"
+CRD_GROUP = "ecr.services.k8s.aws"
+CRD_VERSION = "v1alpha1"
+
+# PyTest marker for the current service
+service_marker = pytest.mark.service(arg=SERVICE_NAME)
+
+bootstrap_directory = Path(__file__).parent
+resource_directory = Path(__file__).parent / "resources"
+def load_ecr_resource(resource_name: str, additional_replacements: Dict[str, Any] = {}):
+    """ Overrides the default `load_resource_file` to access the specific resources
+    directory for the current service.
+    """
+    return load_resource_file(resource_directory, resource_name, additional_replacements=additional_replacements)

--- a/test/e2e/bootstrap_resources.py
+++ b/test/e2e/bootstrap_resources.py
@@ -1,0 +1,34 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Declares the structure of the bootstrapped resources and provides a loader
+for them.
+"""
+
+from dataclasses import dataclass
+from acktest.resources import read_bootstrap_config
+from e2e import bootstrap_directory
+
+@dataclass
+class TestBootstrapResources:
+    pass
+
+_bootstrap_resources = None
+
+def get_bootstrap_resources(bootstrap_file_name: str = "bootstrap.yaml"):
+    global _bootstrap_resources
+    if _bootstrap_resources is None:
+        _bootstrap_resources = TestBootstrapResources(
+            **read_bootstrap_config(bootstrap_directory, bootstrap_file_name=bootstrap_file_name),
+        )
+    return _bootstrap_resources

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -1,0 +1,46 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import os
+import pytest
+
+from acktest import k8s
+
+
+def pytest_addoption(parser):
+    parser.addoption("--runslow", action="store_true", default=False, help="run slow tests")
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "canary: mark test to also run in canary tests"
+    )
+    config.addinivalue_line(
+        "markers", "service(arg): mark test associated with a given service"
+    )
+    config.addinivalue_line(
+        "markers", "slow: mark test as slow to run"
+    )
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)
+
+# Provide a k8s client to interact with the integration test cluster
+@pytest.fixture(scope='class')
+def k8s_client():
+    return k8s._get_k8s_api_client()

--- a/test/e2e/replacement_values.py
+++ b/test/e2e/replacement_values.py
@@ -1,0 +1,20 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Stores the values used by each of the integration tests for replacing the
+ECR-specific test variables.
+"""
+
+REPLACEMENT_VALUES = {
+    
+}

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,0 +1,1 @@
+acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@5ed60a505afa953096e53c9d3d6779830250915b

--- a/test/e2e/resources/repository.yaml
+++ b/test/e2e/resources/repository.yaml
@@ -1,0 +1,9 @@
+apiVersion: ecr.services.k8s.aws/v1alpha1
+kind: Repository
+metadata:
+  name: $REPOSITORY_NAME
+spec:
+  repositoryName: $REPOSITORY_NAME
+  imageScanningConfiguration:
+    scanOnPush: false
+  imageTagMutability: MUTABLE

--- a/test/e2e/service_bootstrap.py
+++ b/test/e2e/service_bootstrap.py
@@ -1,0 +1,33 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+"""Bootstraps the resources required to run the ECR integration tests.
+"""
+
+import boto3
+import logging
+from time import sleep
+
+from acktest import resources
+from acktest.aws.identity import get_region, get_account_id
+from e2e import bootstrap_directory
+from e2e.bootstrap_resources import TestBootstrapResources
+
+def service_bootstrap() -> dict:
+    logging.getLogger().setLevel(logging.INFO)
+
+    return TestBootstrapResources().__dict__
+
+if __name__ == "__main__":
+    config = service_bootstrap()
+    # Write config to current directory by default
+    resources.write_bootstrap_config(config, bootstrap_directory)

--- a/test/e2e/service_cleanup.py
+++ b/test/e2e/service_cleanup.py
@@ -1,0 +1,35 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+"""Cleans up the resources created by the Application Auto Scaling bootstrapping process.
+"""
+
+import boto3
+import logging
+
+from acktest import resources
+from acktest.aws.identity import get_region
+
+from e2e import bootstrap_directory
+from e2e.bootstrap_resources import TestBootstrapResources
+
+
+def service_cleanup(config: dict):
+    logging.getLogger().setLevel(logging.INFO)
+
+    resources = TestBootstrapResources(
+        **config
+    )
+
+if __name__ == "__main__":   
+    bootstrap_config = resources.read_bootstrap_config(bootstrap_directory)
+    service_cleanup(bootstrap_config) 

--- a/test/e2e/tests/__init__.py
+++ b/test/e2e/tests/__init__.py
@@ -1,0 +1,12 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# 	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.

--- a/test/e2e/tests/test_repository.py
+++ b/test/e2e/tests/test_repository.py
@@ -1,0 +1,97 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# 	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Integration tests for the ECR Repository API.
+"""
+
+import boto3
+import pytest
+import time
+import logging
+from typing import Dict, Tuple
+
+from acktest.resources import random_suffix_name
+from acktest.k8s import resource as k8s
+from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_ecr_resource
+from e2e.replacement_values import REPLACEMENT_VALUES
+from e2e.bootstrap_resources import TestBootstrapResources, get_bootstrap_resources
+
+RESOURCE_PLURAL = "repositories"
+
+DELETE_WAIT_AFTER_SECONDS = 10
+CREATE_WAIT_AFTER_SECONDS = 10
+
+@pytest.fixture(scope="module")
+def ecr_client():
+    return boto3.client("ecr")
+
+@service_marker
+@pytest.mark.canary
+class TestRepository:
+
+    def repository_exists(self, ecr_client, repositoryName: str) -> bool:
+        try:
+            resp = ecr_client.describe_repositories(
+                repositoryNames=[repositoryName]
+            )
+        except Exception as e:
+            logging.debug(e)
+            return False
+
+        
+        repositories = resp["repositories"]
+        for repository in repositories:
+            if repository["repositoryName"] == repositoryName:
+                return True
+
+        return False
+
+    def test_smoke(self, ecr_client):
+        resource_name = random_suffix_name("ecr-repository", 16)
+
+        replacements = REPLACEMENT_VALUES.copy()
+        replacements["REPOSITORY_NAME"] = resource_name
+        # Load ECR CR
+        resource_data = load_ecr_resource(
+            "repository",
+            additional_replacements=replacements,
+        )
+        logging.debug(resource_data)
+
+        # Create k8s resource
+        ref = k8s.CustomResourceReference(
+            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+            resource_name, namespace="default",
+        )
+        k8s.create_custom_resource(ref, resource_data)
+        cr = k8s.wait_resource_consumed_by_controller(ref)
+
+        assert cr is not None
+        assert k8s.get_resource_exists(ref)
+
+        time.sleep(CREATE_WAIT_AFTER_SECONDS)
+
+        # Check ECR repository exists
+        exists = self.repository_exists(ecr_client, resource_name)
+        assert exists
+
+        # Delete k8s resource
+        _, deleted = k8s.delete_custom_resource(ref)
+        assert deleted is True
+
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+
+        # Check ECR repository doesn't exists
+        exists = self.repository_exists(ecr_client, resource_name)
+        assert not exists
+


### PR DESCRIPTION
Issue: https://github.com/aws-controllers-k8s/community/issues/758
 
Description:
- Add Python e2e tests using `acktest`
- Add Github actions workflows

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.