### PR TITLE
Runtime `v0.2.0` and field rename

### DIFF
--- a/apis/v1alpha1/repository.go
+++ b/apis/v1alpha1/repository.go
@@ -37,7 +37,7 @@ type RepositorySpec struct {
 	// on its own (such as nginx-web-app) or it can be prepended with a namespace
 	// to group the repository into a category (such as project-a/nginx-web-app).
 	// +kubebuilder:validation:Required
-	RepositoryName *string `json:"repositoryName"`
+	Name *string `json:"name"`
 	// The metadata that you apply to the repository to help you categorize and
 	// organize them. Each tag consists of a key and an optional value, both of
 	// which you define. Tag keys can have a maximum character length of 128 characters,

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -28,36 +28,69 @@ var (
 	_ = ackv1alpha1.AWSAccountID("")
 )
 
+// The encryption configuration for the repository. This determines how the
+// contents of your repository are encrypted at rest.
+//
+// By default, when no encryption configuration is set or the AES256 encryption
+// type is used, Amazon ECR uses server-side encryption with Amazon S3-managed
+// encryption keys which encrypts your data at rest using an AES-256 encryption
+// algorithm. This does not require any action on your part.
+//
+// For more control over the encryption of the contents of your repository,
+// you can use server-side encryption with customer master keys (CMKs) stored
+// in AWS Key Management Service (AWS KMS) to encrypt your images. For more
+// information, see Amazon ECR encryption at rest (https://docs.aws.amazon.com/AmazonECR/latest/userguide/encryption-at-rest.html)
+// in the Amazon Elastic Container Registry User Guide.
 type EncryptionConfiguration struct {
 	EncryptionType *string `json:"encryptionType,omitempty"`
 	KMSKey         *string `json:"kmsKey,omitempty"`
 }
 
+// An object representing an Amazon ECR image.
 type Image struct {
 	RegistryID     *string `json:"registryID,omitempty"`
 	RepositoryName *string `json:"repositoryName,omitempty"`
 }
 
+// An object that describes an image returned by a DescribeImages operation.
 type ImageDetail struct {
 	RegistryID     *string `json:"registryID,omitempty"`
 	RepositoryName *string `json:"repositoryName,omitempty"`
 }
 
+// Contains information about an image scan finding.
 type ImageScanFinding struct {
 	URI *string `json:"uri,omitempty"`
 }
 
+// The image scanning configuration for a repository.
 type ImageScanningConfiguration struct {
 	ScanOnPush *bool `json:"scanOnPush,omitempty"`
 }
 
+// An array of objects representing the details of a replication destination.
 type ReplicationDestination struct {
 	RegistryID *string `json:"registryID,omitempty"`
 }
 
+// An object representing a repository.
 type Repository_SDK struct {
-	CreatedAt                  *metav1.Time                `json:"createdAt,omitempty"`
-	EncryptionConfiguration    *EncryptionConfiguration    `json:"encryptionConfiguration,omitempty"`
+	CreatedAt *metav1.Time `json:"createdAt,omitempty"`
+	// The encryption configuration for the repository. This determines how the
+	// contents of your repository are encrypted at rest.
+	//
+	// By default, when no encryption configuration is set or the AES256 encryption
+	// type is used, Amazon ECR uses server-side encryption with Amazon S3-managed
+	// encryption keys which encrypts your data at rest using an AES-256 encryption
+	// algorithm. This does not require any action on your part.
+	//
+	// For more control over the encryption of the contents of your repository,
+	// you can use server-side encryption with customer master keys (CMKs) stored
+	// in AWS Key Management Service (AWS KMS) to encrypt your images. For more
+	// information, see Amazon ECR encryption at rest (https://docs.aws.amazon.com/AmazonECR/latest/userguide/encryption-at-rest.html)
+	// in the Amazon Elastic Container Registry User Guide.
+	EncryptionConfiguration *EncryptionConfiguration `json:"encryptionConfiguration,omitempty"`
+	// The image scanning configuration for a repository.
 	ImageScanningConfiguration *ImageScanningConfiguration `json:"imageScanningConfiguration,omitempty"`
 	ImageTagMutability         *string                     `json:"imageTagMutability,omitempty"`
 	RegistryID                 *string                     `json:"registryID,omitempty"`
@@ -66,6 +99,10 @@ type Repository_SDK struct {
 	RepositoryURI              *string                     `json:"repositoryURI,omitempty"`
 }
 
+// The metadata that you apply to a resource to help you categorize and organize
+// them. Each tag consists of a key and an optional value, both of which you
+// define. Tag keys can have a maximum character length of 128 characters, and
+// tag values can have a maximum length of 256 characters.
 type Tag struct {
 	Key   *string `json:"key,omitempty"`
 	Value *string `json:"value,omitempty"`

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -236,8 +236,8 @@ func (in *RepositorySpec) DeepCopyInto(out *RepositorySpec) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.RepositoryName != nil {
-		in, out := &in.RepositoryName, &out.RepositoryName
+	if in.Name != nil {
+		in, out := &in.Name, &out.Name
 		*out = new(string)
 		**out = **in
 	}

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -66,6 +66,7 @@ func main() {
 		MetricsBindAddress: ackCfg.MetricsAddr,
 		LeaderElection:     ackCfg.EnableLeaderElection,
 		LeaderElectionID:   awsServiceAPIGroup,
+		Namespace:          ackCfg.WatchNamespace,
 	})
 	if err != nil {
 		setupLog.Error(

--- a/config/controller/deployment.yaml
+++ b/config/controller/deployment.yaml
@@ -36,6 +36,8 @@ spec:
         - "$(ACK_LOG_LEVEL)"
         - --resource-tags
         - "$(ACK_RESOURCE_TAGS)"
+        - --watch-namespace
+        - "$(ACK_WATCH_NAMESPACE)"
         image: controller:latest
         name: controller
         ports:

--- a/config/crd/bases/ecr.services.k8s.aws_repositories.yaml
+++ b/config/crd/bases/ecr.services.k8s.aws_repositories.yaml
@@ -61,7 +61,7 @@ spec:
                   all image tags within the repository will be immutable which will
                   prevent them from being overwritten.
                 type: string
-              repositoryName:
+              name:
                 description: The name to use for the repository. The repository name
                   may be specified on its own (such as nginx-web-app) or it can be
                   prepended with a namespace to group the repository into a category
@@ -74,6 +74,11 @@ spec:
                   maximum character length of 128 characters, and tag values can have
                   a maximum length of 256 characters.
                 items:
+                  description: The metadata that you apply to a resource to help you
+                    categorize and organize them. Each tag consists of a key and an
+                    optional value, both of which you define. Tag keys can have a
+                    maximum character length of 128 characters, and tag values can
+                    have a maximum length of 256 characters.
                   properties:
                     key:
                       type: string
@@ -82,7 +87,7 @@ spec:
                   type: object
                 type: array
             required:
-            - repositoryName
+            - name
             type: object
           status:
             description: RepositoryStatus defines the observed state of Repository

--- a/generator.yaml
+++ b/generator.yaml
@@ -1,11 +1,22 @@
 resources:
   Repository:
+    renames:
+      operations:
+        CreateRepository:
+          input_fields:
+            RepositoryName: Name
+        DeleteRepository:
+          input_fields:
+            RepositoryName: Name
+        DescribeRepositories:
+          input_fields:
+            RepositoryName: Name
     exceptions:
       errors:
         404:
           code: RepositoryNotFoundException
     list_operation:
       match_fields:
-        - RepositoryName
+        - Name
     update_operation:
       custom_method_name: customUpdateRepository

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/ecr-controller
 go 1.14
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.1.1
+	github.com/aws-controllers-k8s/runtime v0.2.0
 	github.com/aws/aws-sdk-go v1.38.35
 	github.com/go-logr/logr v0.1.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -23,9 +23,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/runtime v0.1.1 h1:BFL008As5uz+3RkYvkYFL8scfX9h4ZDnX+T9+s38JvI=
-github.com/aws-controllers-k8s/runtime v0.1.1/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
-github.com/aws/aws-sdk-go v1.37.4 h1:tWxrpMK/oRSXVnjUzhGeCWLR00fW0WF4V4sycYPPrJ8=
+github.com/aws-controllers-k8s/runtime v0.2.0 h1:gd0Kq8xGelgkZoNjr8yZbHfpvPA1R+wfMCi1lT4H8x4=
+github.com/aws-controllers-k8s/runtime v0.2.0/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
 github.com/aws/aws-sdk-go v1.37.4/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.38.35 h1:7AlAO0FC+8nFjxiGKEmq0QLpiA8/XFr6eIxgRTwkdTg=
 github.com/aws/aws-sdk-go v1.38.35/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
@@ -312,7 +311,6 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190320223903-b7391e95e576/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190617133340-57b3e21c3d56/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975 h1:/Tl7pH94bvbAAHBdZJT947M/+gp0+CqQXDtMRC0fseo=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -365,14 +363,12 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7 h1:HmbHVPwrPEKPGLAcHSrMe6+hqSUlvZU0rab6x5EXfGU=
 golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/pkg/resource/repository/custom_update_api.go
+++ b/pkg/resource/repository/custom_update_api.go
@@ -72,7 +72,7 @@ func (rm *resourceManager) updateImageScanningConfiguration(
 ) (*resource, error) {
 	dspec := desired.ko.Spec
 	input := &svcsdk.PutImageScanningConfigurationInput{
-		RepositoryName: aws.String(*dspec.RepositoryName),
+		RepositoryName: aws.String(*dspec.Name),
 	}
 	if dspec.ImageScanningConfiguration == nil {
 		// There isn't any "reset" behaviour and the image scanning
@@ -99,7 +99,7 @@ func (rm *resourceManager) updateImageTagMutability(
 ) (*resource, error) {
 	dspec := desired.ko.Spec
 	input := &svcsdk.PutImageTagMutabilityInput{
-		RepositoryName: aws.String(*dspec.RepositoryName),
+		RepositoryName: aws.String(*dspec.Name),
 	}
 	if dspec.ImageTagMutability == nil {
 		// There isn't any "reset" behaviour and the image scanning

--- a/pkg/resource/repository/delta.go
+++ b/pkg/resource/repository/delta.go
@@ -17,12 +17,6 @@ package repository
 
 import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
-
-	svcapitypes "github.com/aws-controllers-k8s/ecr-controller/apis/v1alpha1"
-)
-
-var (
-	_ = svcapitypes.GroupVersion
 )
 
 // newResourceDelta returns a new `ackcompare.Delta` used to compare two
@@ -74,22 +68,13 @@ func newResourceDelta(
 			delta.Add("Spec.ImageTagMutability", a.ko.Spec.ImageTagMutability, b.ko.Spec.ImageTagMutability)
 		}
 	}
-	if ackcompare.HasNilDifference(a.ko.Spec.RepositoryName, b.ko.Spec.RepositoryName) {
-		delta.Add("Spec.RepositoryName", a.ko.Spec.RepositoryName, b.ko.Spec.RepositoryName)
-	} else if a.ko.Spec.RepositoryName != nil && b.ko.Spec.RepositoryName != nil {
-		if *a.ko.Spec.RepositoryName != *b.ko.Spec.RepositoryName {
-			delta.Add("Spec.RepositoryName", a.ko.Spec.RepositoryName, b.ko.Spec.RepositoryName)
+	if ackcompare.HasNilDifference(a.ko.Spec.Name, b.ko.Spec.Name) {
+		delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
+	} else if a.ko.Spec.Name != nil && b.ko.Spec.Name != nil {
+		if *a.ko.Spec.Name != *b.ko.Spec.Name {
+			delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
 		}
 	}
 
-	if !equalTagList(a.ko.Spec.Tags, b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	}
-
 	return delta
-}
-
-func equalTagList(a, b []*svcapitypes.Tag) bool {
-	//TODO(a-hilaly) implement this function
-	return true
 }

--- a/pkg/resource/repository/resource.go
+++ b/pkg/resource/repository/resource.go
@@ -25,6 +25,11 @@ import (
 	svcapitypes "github.com/aws-controllers-k8s/ecr-controller/apis/v1alpha1"
 )
 
+// Hack to avoid import errors during build...
+var (
+	_ = &ackerrors.MissingNameIdentifier
+)
+
 // resource implements the `aws-controller-k8s/runtime/pkg/types.AWSResource`
 // interface
 type resource struct {
@@ -80,6 +85,6 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 	if identifier.NameOrID == nil {
 		return ackerrors.MissingNameIdentifier
 	}
-	r.ko.Spec.RepositoryName = identifier.NameOrID
+	r.ko.Spec.Name = identifier.NameOrID
 	return nil
 }

--- a/pkg/resource/repository/sdk.go
+++ b/pkg/resource/repository/sdk.go
@@ -63,6 +63,7 @@ func (rm *resourceManager) sdkFind(
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
+
 	found := false
 	for _, elem := range resp.Repositories {
 		if elem.CreatedAt != nil {
@@ -109,14 +110,14 @@ func (rm *resourceManager) sdkFind(
 			ko.Status.ACKResourceMetadata.ARN = &tmpARN
 		}
 		if elem.RepositoryName != nil {
-			if ko.Spec.RepositoryName != nil {
-				if *elem.RepositoryName != *ko.Spec.RepositoryName {
+			if ko.Spec.Name != nil {
+				if *elem.RepositoryName != *ko.Spec.Name {
 					continue
 				}
 			}
-			ko.Spec.RepositoryName = elem.RepositoryName
+			ko.Spec.Name = elem.RepositoryName
 		} else {
-			ko.Spec.RepositoryName = nil
+			ko.Spec.Name = nil
 		}
 		if elem.RepositoryUri != nil {
 			ko.Status.RepositoryURI = elem.RepositoryUri
@@ -225,8 +226,8 @@ func (rm *resourceManager) newCreateRequestPayload(
 	if r.ko.Spec.ImageTagMutability != nil {
 		res.SetImageTagMutability(*r.ko.Spec.ImageTagMutability)
 	}
-	if r.ko.Spec.RepositoryName != nil {
-		res.SetRepositoryName(*r.ko.Spec.RepositoryName)
+	if r.ko.Spec.Name != nil {
+		res.SetRepositoryName(*r.ko.Spec.Name)
 	}
 	if r.ko.Spec.Tags != nil {
 		f4 := []*svcsdk.Tag{}
@@ -282,8 +283,8 @@ func (rm *resourceManager) newDeleteRequestPayload(
 	if r.ko.Status.RegistryID != nil {
 		res.SetRegistryId(*r.ko.Status.RegistryID)
 	}
-	if r.ko.Spec.RepositoryName != nil {
-		res.SetRepositoryName(*r.ko.Spec.RepositoryName)
+	if r.ko.Spec.Name != nil {
+		res.SetRepositoryName(*r.ko.Spec.Name)
 	}
 
 	return res, nil

--- a/test/e2e/resources/repository.yaml
+++ b/test/e2e/resources/repository.yaml
@@ -3,7 +3,7 @@ kind: Repository
 metadata:
   name: $REPOSITORY_NAME
 spec:
-  repositoryName: $REPOSITORY_NAME
+  name: $REPOSITORY_NAME
   imageScanningConfiguration:
     scanOnPush: false
   imageTagMutability: MUTABLE


### PR DESCRIPTION
Part of https://github.com/aws-controllers-k8s/community/issues/790

Description of changes:
- Regenerate controller with `ack-generate` v0.2.0
- Updated `go.mod` to use runtime `v0.2.0`
- Updated `generator.yaml` to rename `RepositoryName` field to `Name`
- Executed `go mod tidy`

New `generator.yaml`:
```yaml
resources:
  Repository:
    renames:
      operations:
        CreateRepository:
          input_fields:
            RepositoryName: Name
        DeleteRepository:
          input_fields:
            RepositoryName: Name
        DescribeRepositories:
          input_fields:
            RepositoryName: Name
    exceptions:
      errors:
        404:
          code: RepositoryNotFoundException
    list_operation:
      match_fields:
        - Name
    update_operation:
      custom_method_name: customUpdateRepository
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.