### PR TITLE
Regenerates the ECR controller with `ack-generate` v0.3.1

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,0 +1,14 @@
+ack_generate_info:
+  build_date: "2021-06-24T14:47:44Z"
+  build_hash: 9c35918f8a98b41ada10cb3aa460dbf463428463
+  go_version: go1.16.4 linux/amd64
+  version: v0.2.3
+api_directory_checksum: 1c67711ffbdd9a4ed8e2051fbb70e84c7fd98b82
+api_version: v1alpha1
+aws_sdk_go_version: v1.38.60
+generator_config_info:
+  file_checksum: 8c4aaf877173015433fee1c3ecf67e23dc86be89
+  original_file_name: generator.yaml
+last_modification:
+  reason: API generation
+  timestamp: 2021-06-24 14:47:46.110578541 +0000 UTC

--- a/apis/v1alpha1/repository.go
+++ b/apis/v1alpha1/repository.go
@@ -20,7 +20,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// RepositorySpec defines the desired state of Repository
+// RepositorySpec defines the desired state of Repository.
+//
+// An object representing a repository.
 type RepositorySpec struct {
 	// The encryption configuration for the repository. This determines how the
 	// contents of your repository are encrypted at rest.

--- a/config/crd/bases/ecr.services.k8s.aws_repositories.yaml
+++ b/config/crd/bases/ecr.services.k8s.aws_repositories.yaml
@@ -34,7 +34,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: RepositorySpec defines the desired state of Repository
+            description: "RepositorySpec defines the desired state of Repository.
+              \n An object representing a repository."
             properties:
               encryptionConfiguration:
                 description: The encryption configuration for the repository. This

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/ecr-controller
 go 1.14
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.2.1
+	github.com/aws-controllers-k8s/runtime v0.3.0
 	github.com/aws/aws-sdk-go v1.38.35
 	github.com/go-logr/logr v0.1.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -23,10 +23,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/runtime v0.2.0 h1:gd0Kq8xGelgkZoNjr8yZbHfpvPA1R+wfMCi1lT4H8x4=
-github.com/aws-controllers-k8s/runtime v0.2.0/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
-github.com/aws-controllers-k8s/runtime v0.2.1 h1:vItjQ5/pZjr8Z7cR35sQKcSjQy19mF3qOfbUitWMt1A=
-github.com/aws-controllers-k8s/runtime v0.2.1/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
+github.com/aws-controllers-k8s/runtime v0.3.0 h1:cuaKAhru2+XqftIBb/QITMLmgDjf1SYNVerHVG7PvjE=
+github.com/aws-controllers-k8s/runtime v0.3.0/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
 github.com/aws/aws-sdk-go v1.37.4/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.38.35 h1:7AlAO0FC+8nFjxiGKEmq0QLpiA8/XFr6eIxgRTwkdTg=
 github.com/aws/aws-sdk-go v1.38.35/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=

--- a/pkg/resource/repository/custom_update_api.go
+++ b/pkg/resource/repository/custom_update_api.go
@@ -49,13 +49,13 @@ func (rm *resourceManager) customUpdateRepository(
 	var err error
 	var updated *resource
 	updated = desired
-	if delta.DifferentAt("ImageScanningConfiguration") {
+	if delta.DifferentAt("Spec.ImageScanningConfiguration") {
 		updated, err = rm.updateImageScanningConfiguration(ctx, updated)
 		if err != nil {
 			return nil, err
 		}
 	}
-	if delta.DifferentAt("ImageTagMutability") {
+	if delta.DifferentAt("Spec.ImageTagMutability") {
 		updated, err = rm.updateImageTagMutability(ctx, updated)
 		if err != nil {
 			return nil, err

--- a/pkg/resource/repository/manager.go
+++ b/pkg/resource/repository/manager.go
@@ -18,16 +18,16 @@ package repository
 import (
 	"context"
 	"fmt"
-	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/ecr"
 	svcsdkapi "github.com/aws/aws-sdk-go/service/ecr/ecriface"
@@ -87,6 +87,9 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
+		if observed != nil {
+			return rm.onError(observed, err)
+		}
 		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)
@@ -194,7 +197,7 @@ func (rm *resourceManager) onError(
 	r *resource,
 	err error,
 ) (acktypes.AWSResource, error) {
-	r1, updated := rm.updateConditions(r, err)
+	r1, updated := rm.updateConditions(r, false, err)
 	if !updated {
 		return r, err
 	}
@@ -214,7 +217,7 @@ func (rm *resourceManager) onError(
 func (rm *resourceManager) onSuccess(
 	r *resource,
 ) (acktypes.AWSResource, error) {
-	r1, updated := rm.updateConditions(r, nil)
+	r1, updated := rm.updateConditions(r, true, nil)
 	if !updated {
 		return r, nil
 	}

--- a/pkg/resource/repository/manager_factory.go
+++ b/pkg/resource/repository/manager_factory.go
@@ -79,6 +79,12 @@ func (f *resourceManagerFactory) IsAdoptable() bool {
 	return true
 }
 
+// RequeueOnSuccessSeconds returns true if the resource should be requeued after specified seconds
+// Default is false which means resource will not be requeued after success.
+func (f *resourceManagerFactory) RequeueOnSuccessSeconds() int {
+	return 0
+}
+
 func newResourceManagerFactory() *resourceManagerFactory {
 	return &resourceManagerFactory{
 		rmCache: map[string]*resourceManager{},

--- a/pkg/resource/repository/resource.go
+++ b/pkg/resource/repository/resource.go
@@ -74,6 +74,11 @@ func (r *resource) Conditions() []*ackv1alpha1.Condition {
 	return r.ko.Status.Conditions
 }
 
+// ReplaceConditions sets the Conditions status field for the resource
+func (r *resource) ReplaceConditions(conditions []*ackv1alpha1.Condition) {
+	r.ko.Status.Conditions = conditions
+}
+
 // SetObjectMeta sets the ObjectMeta field for the resource
 func (r *resource) SetObjectMeta(meta metav1.ObjectMeta) {
 	r.ko.ObjectMeta = meta

--- a/pkg/resource/repository/sdk.go
+++ b/pkg/resource/repository/sdk.go
@@ -22,6 +22,7 @@ import (
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/ecr"
 	corev1 "k8s.io/api/core/v1"
@@ -45,19 +46,22 @@ var (
 func (rm *resourceManager) sdkFind(
 	ctx context.Context,
 	r *resource,
-) (*resource, error) {
+) (latest *resource, err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.sdkFind")
+	defer exit(err)
 	input, err := rm.newListRequestPayload(r)
 	if err != nil {
 		return nil, err
 	}
-
-	resp, respErr := rm.sdkapi.DescribeRepositoriesWithContext(ctx, input)
-	rm.metrics.RecordAPICall("READ_MANY", "DescribeRepositories", respErr)
-	if respErr != nil {
-		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "RepositoryNotFoundException" {
+	var resp *svcsdk.DescribeRepositoriesOutput
+	resp, err = rm.sdkapi.DescribeRepositoriesWithContext(ctx, input)
+	rm.metrics.RecordAPICall("READ_MANY", "DescribeRepositories", err)
+	if err != nil {
+		if awsErr, ok := ackerr.AWSError(err); ok && awsErr.Code() == "RepositoryNotFoundException" {
 			return nil, ackerr.NotFound
 		}
-		return nil, respErr
+		return nil, err
 	}
 
 	// Merge in the information we read from the API call above to the copy of
@@ -132,7 +136,6 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
-
 	return &resource{ko}, nil
 }
 
@@ -151,24 +154,30 @@ func (rm *resourceManager) newListRequestPayload(
 }
 
 // sdkCreate creates the supplied resource in the backend AWS service API and
-// returns a new resource with any fields in the Status field filled in
+// returns a copy of the resource with resource fields (in both Spec and
+// Status) filled in with values from the CREATE API operation's Output shape.
 func (rm *resourceManager) sdkCreate(
 	ctx context.Context,
-	r *resource,
-) (*resource, error) {
-	input, err := rm.newCreateRequestPayload(ctx, r)
+	desired *resource,
+) (created *resource, err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.sdkCreate")
+	defer exit(err)
+	input, err := rm.newCreateRequestPayload(ctx, desired)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, respErr := rm.sdkapi.CreateRepositoryWithContext(ctx, input)
-	rm.metrics.RecordAPICall("CREATE", "CreateRepository", respErr)
-	if respErr != nil {
-		return nil, respErr
+	var resp *svcsdk.CreateRepositoryOutput
+	_ = resp
+	resp, err = rm.sdkapi.CreateRepositoryWithContext(ctx, input)
+	rm.metrics.RecordAPICall("CREATE", "CreateRepository", err)
+	if err != nil {
+		return nil, err
 	}
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
-	ko := r.ko.DeepCopy()
+	ko := desired.ko.DeepCopy()
 
 	if resp.Repository.CreatedAt != nil {
 		ko.Status.CreatedAt = &metav1.Time{*resp.Repository.CreatedAt}
@@ -194,7 +203,6 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
-
 	return &resource{ko}, nil
 }
 
@@ -262,15 +270,17 @@ func (rm *resourceManager) sdkUpdate(
 func (rm *resourceManager) sdkDelete(
 	ctx context.Context,
 	r *resource,
-) error {
-
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.sdkDelete")
+	defer exit(err)
 	input, err := rm.newDeleteRequestPayload(r)
 	if err != nil {
 		return err
 	}
-	_, respErr := rm.sdkapi.DeleteRepositoryWithContext(ctx, input)
-	rm.metrics.RecordAPICall("DELETE", "DeleteRepository", respErr)
-	return respErr
+	_, err = rm.sdkapi.DeleteRepositoryWithContext(ctx, input)
+	rm.metrics.RecordAPICall("DELETE", "DeleteRepository", err)
+	return err
 }
 
 // newDeleteRequestPayload returns an SDK-specific struct for the HTTP request
@@ -309,6 +319,7 @@ func (rm *resourceManager) setStatusDefaults(
 // else it returns nil, false
 func (rm *resourceManager) updateConditions(
 	r *resource,
+	onSuccess bool,
 	err error,
 ) (*resource, bool) {
 	ko := r.ko.DeepCopy()
@@ -317,12 +328,16 @@ func (rm *resourceManager) updateConditions(
 	// Terminal condition
 	var terminalCondition *ackv1alpha1.Condition = nil
 	var recoverableCondition *ackv1alpha1.Condition = nil
+	var syncCondition *ackv1alpha1.Condition = nil
 	for _, condition := range ko.Status.Conditions {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
 			terminalCondition = condition
 		}
 		if condition.Type == ackv1alpha1.ConditionTypeRecoverable {
 			recoverableCondition = condition
+		}
+		if condition.Type == ackv1alpha1.ConditionTypeResourceSynced {
+			syncCondition = condition
 		}
 	}
 
@@ -364,7 +379,9 @@ func (rm *resourceManager) updateConditions(
 			recoverableCondition.Message = nil
 		}
 	}
-	if terminalCondition != nil || recoverableCondition != nil {
+	// Required to avoid the "declared but not used" error in the default case
+	_ = syncCondition
+	if terminalCondition != nil || recoverableCondition != nil || syncCondition != nil {
 		return &resource{ko}, true // updated
 	}
 	return nil, false // not updated


### PR DESCRIPTION
Regenerates the ECR controller with `ack-generate` v0.3.1` to get to ACK runtime v0.3.0

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.