### PR TITLE
bring ecr-controller to ACK runtime v0.11.0

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,14 +1,14 @@
 ack_generate_info:
-  build_date: "2021-06-24T14:47:44Z"
-  build_hash: 9c35918f8a98b41ada10cb3aa460dbf463428463
-  go_version: go1.16.4 linux/amd64
-  version: v0.2.3
-api_directory_checksum: 1c67711ffbdd9a4ed8e2051fbb70e84c7fd98b82
+  build_date: "2021-08-17T13:53:27Z"
+  build_hash: 64436ce7e8d7f7356daa6888600a68da4f09a5ac
+  go_version: go1.15.5 linux/amd64
+  version: v0.11.0
+api_directory_checksum: 3c829828db77ef587929da78f41d52b2459fb054
 api_version: v1alpha1
-aws_sdk_go_version: v1.38.60
+aws_sdk_go_version: v1.38.35
 generator_config_info:
   file_checksum: 8c4aaf877173015433fee1c3ecf67e23dc86be89
   original_file_name: generator.yaml
 last_modification:
   reason: API generation
-  timestamp: 2021-06-24 14:47:46.110578541 +0000 UTC
+  timestamp: 2021-08-17 13:53:33.069703342 +0000 UTC

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -1,0 +1,22 @@
+resources:
+  Repository:
+    renames:
+      operations:
+        CreateRepository:
+          input_fields:
+            RepositoryName: Name
+        DeleteRepository:
+          input_fields:
+            RepositoryName: Name
+        DescribeRepositories:
+          input_fields:
+            RepositoryName: Name
+    exceptions:
+      errors:
+        404:
+          code: RepositoryNotFoundException
+    list_operation:
+      match_fields:
+        - Name
+    update_operation:
+      custom_method_name: customUpdateRepository

--- a/apis/v1alpha1/repository.go
+++ b/apis/v1alpha1/repository.go
@@ -52,18 +52,23 @@ type RepositoryStatus struct {
 	// All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
 	// that is used to contain resource sync state, account ownership,
 	// constructed ARN for the resource
+	// +kubebuilder:validation:Optional
 	ACKResourceMetadata *ackv1alpha1.ResourceMetadata `json:"ackResourceMetadata"`
 	// All CRS managed by ACK have a common `Status.Conditions` member that
 	// contains a collection of `ackv1alpha1.Condition` objects that describe
 	// the various terminal states of the CR and its backend AWS service API
 	// resource
+	// +kubebuilder:validation:Optional
 	Conditions []*ackv1alpha1.Condition `json:"conditions"`
 	// The date and time, in JavaScript date format, when the repository was created.
+	// +kubebuilder:validation:Optional
 	CreatedAt *metav1.Time `json:"createdAt,omitempty"`
 	// The AWS account ID associated with the registry that contains the repository.
+	// +kubebuilder:validation:Optional
 	RegistryID *string `json:"registryID,omitempty"`
 	// The URI for the repository. You can use this URI for container image push
 	// and pull operations.
+	// +kubebuilder:validation:Optional
 	RepositoryURI *string `json:"repositoryURI,omitempty"`
 }
 

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -20,6 +20,9 @@ import (
 
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
 	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
+	ackrtutil "github.com/aws-controllers-k8s/runtime/pkg/util"
+	ackrtwebhook "github.com/aws-controllers-k8s/runtime/pkg/webhook"
+	svcsdk "github.com/aws/aws-sdk-go/service/ecr"
 	flag "github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -34,14 +37,16 @@ import (
 )
 
 var (
-	awsServiceAPIGroup = "ecr.services.k8s.aws"
-	awsServiceAlias    = "ecr"
-	scheme             = runtime.NewScheme()
-	setupLog           = ctrlrt.Log.WithName("setup")
+	awsServiceAPIGroup    = "ecr.services.k8s.aws"
+	awsServiceAlias       = "ecr"
+	awsServiceEndpointsID = svcsdk.EndpointsID
+	scheme                = runtime.NewScheme()
+	setupLog              = ctrlrt.Log.WithName("setup")
 )
 
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
+
 	_ = svctypes.AddToScheme(scheme)
 	_ = ackv1alpha1.AddToScheme(scheme)
 }
@@ -60,9 +65,19 @@ func main() {
 		os.Exit(1)
 	}
 
+	host, port, err := ackrtutil.GetHostPort(ackCfg.WebhookServerAddr)
+	if err != nil {
+		setupLog.Error(
+			err, "Unable to parse webhook server address.",
+			"aws.service", awsServiceAlias,
+		)
+		os.Exit(1)
+	}
+
 	mgr, err := ctrlrt.NewManager(ctrlrt.GetConfigOrDie(), ctrlrt.Options{
 		Scheme:             scheme,
-		Port:               ackCfg.BindPort,
+		Port:               port,
+		Host:               host,
 		MetricsBindAddress: ackCfg.MetricsAddr,
 		LeaderElection:     ackCfg.EnableLeaderElection,
 		LeaderElectionID:   awsServiceAPIGroup,
@@ -83,7 +98,7 @@ func main() {
 		"aws.service", awsServiceAlias,
 	)
 	sc := ackrt.NewServiceController(
-		awsServiceAlias, awsServiceAPIGroup,
+		awsServiceAlias, awsServiceAPIGroup, awsServiceEndpointsID,
 		ackrt.VersionInfo{}, // TODO: populate version info
 	).WithLogger(
 		ctrlrt.Log,
@@ -92,6 +107,20 @@ func main() {
 	).WithPrometheusRegistry(
 		ctrlrtmetrics.Registry,
 	)
+
+	if ackCfg.EnableWebhookServer {
+		webhooks := ackrtwebhook.GetWebhooks()
+		for _, webhook := range webhooks {
+			if err := webhook.Setup(mgr); err != nil {
+				setupLog.Error(
+					err, "unable to register webhook "+webhook.UID(),
+					"aws.service", awsServiceAlias,
+				)
+
+			}
+		}
+	}
+
 	if err = sc.BindControllerManager(mgr, ackCfg); err != nil {
 		setupLog.Error(
 			err, "unable bind to controller manager to service controller",

--- a/config/crd/bases/ecr.services.k8s.aws_repositories.yaml
+++ b/config/crd/bases/ecr.services.k8s.aws_repositories.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: repositories.ecr.services.k8s.aws
 spec:
@@ -162,9 +162,6 @@ spec:
                 description: The URI for the repository. You can use this URI for
                   container image push and pull operations.
                 type: string
-            required:
-            - ackResourceMetadata
-            - conditions
             type: object
         type: object
     served: true

--- a/config/crd/common/bases/services.k8s.aws_adoptedresources.yaml
+++ b/config/crd/common/bases/services.k8s.aws_adoptedresources.yaml
@@ -40,6 +40,12 @@ spec:
                 description: AWSIdentifiers provide all unique ways to reference an
                   AWS resource.
                 properties:
+                  additionalKeys:
+                    additionalProperties:
+                      type: string
+                    description: AdditionalKeys represents any additional arbitrary
+                      identifiers used when describing the target resource.
+                    type: object
                   arn:
                     description: ARN is the AWS Resource Name for the resource. It
                       is a globally unique identifier.

--- a/config/overlays/namespaced/kustomization.yaml
+++ b/config/overlays/namespaced/kustomization.yaml
@@ -1,0 +1,15 @@
+resources:
+- ../../default
+patches:
+- path: role.json
+  target:
+    group: rbac.authorization.k8s.io
+    version: v1
+    kind: ClusterRole
+    name: ack-ecr-controller
+- path: role-binding.json
+  target:
+    group: rbac.authorization.k8s.io
+    version: v1
+    kind: ClusterRoleBinding
+    name: ack-ecr-controller-rolebinding

--- a/config/overlays/namespaced/role-binding.json
+++ b/config/overlays/namespaced/role-binding.json
@@ -1,0 +1,3 @@
+[{"op": "replace", "path": "/kind", "value": "RoleBinding"},
+{"op": "add", "path": "/metadata/namespace", "value":  "ack-system"},
+{"op": "replace", "path": "/roleRef/kind", "value": "Role"}]

--- a/config/overlays/namespaced/role.json
+++ b/config/overlays/namespaced/role.json
@@ -1,0 +1,2 @@
+[{"op": "replace", "path": "/kind", "value": "Role"},
+{"op": "add", "path": "/metadata/namespace", "value": "ack-system"}]

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/ecr-controller
 go 1.14
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.3.0
+	github.com/aws-controllers-k8s/runtime v0.11.0
 	github.com/aws/aws-sdk-go v1.38.35
 	github.com/go-logr/logr v0.1.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -23,9 +23,9 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/runtime v0.3.0 h1:cuaKAhru2+XqftIBb/QITMLmgDjf1SYNVerHVG7PvjE=
-github.com/aws-controllers-k8s/runtime v0.3.0/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
-github.com/aws/aws-sdk-go v1.37.4/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
+github.com/aws-controllers-k8s/runtime v0.11.0 h1:M8gSC6qs2yxLDRh75htYdal4lPf3Uodh0SKeiXSgPno=
+github.com/aws-controllers-k8s/runtime v0.11.0/go.mod h1:kG2WM4JAmLgf67cgZV9IZUkY2DsrUzsaNbmhFMfb05c=
+github.com/aws/aws-sdk-go v1.37.10/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.38.35 h1:7AlAO0FC+8nFjxiGKEmq0QLpiA8/XFr6eIxgRTwkdTg=
 github.com/aws/aws-sdk-go v1.38.35/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/pkg/resource/repository/delta.go
+++ b/pkg/resource/repository/delta.go
@@ -16,7 +16,14 @@
 package repository
 
 import (
+	"reflect"
+
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+)
+
+// Hack to avoid import errors during build...
+var (
+	_ = &reflect.Method{}
 )
 
 // newResourceDelta returns a new `ackcompare.Delta` used to compare two
@@ -74,6 +81,9 @@ func newResourceDelta(
 		if *a.ko.Spec.Name != *b.ko.Spec.Name {
 			delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
 		}
+	}
+	if !reflect.DeepEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 
 	return delta

--- a/pkg/resource/repository/descriptor.go
+++ b/pkg/resource/repository/descriptor.go
@@ -70,16 +70,6 @@ func (d *resourceDescriptor) Delta(a, b acktypes.AWSResource) *ackcompare.Delta 
 	return newResourceDelta(a.(*resource), b.(*resource))
 }
 
-// UpdateCRStatus accepts an AWSResource object and changes the Status
-// sub-object of the AWSResource's Kubernetes custom resource (CR) and
-// returns whether any changes were made
-func (d *resourceDescriptor) UpdateCRStatus(
-	res acktypes.AWSResource,
-) (bool, error) {
-	updated := true
-	return updated, nil
-}
-
 // IsManaged returns true if the supplied AWSResource is under the management
 // of an ACK service controller. What this means in practice is that the
 // underlying custom resource (CR) in the AWSResource has had a

--- a/pkg/resource/repository/manager.go
+++ b/pkg/resource/repository/manager.go
@@ -18,12 +18,16 @@ package repository
 import (
 	"context"
 	"fmt"
+	"time"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
+	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/go-logr/logr"
@@ -35,6 +39,8 @@ import (
 
 // +kubebuilder:rbac:groups=ecr.services.k8s.aws,resources=repositories,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ecr.services.k8s.aws,resources=repositories/status,verbs=get;update;patch
+
+var lateInitializeFieldNames = []string{}
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -142,11 +148,12 @@ func (rm *resourceManager) Update(
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
-// service API.
+// service API, returning an AWSResource representing the
+// resource being deleted (if delete is asynchronous and takes time)
 func (rm *resourceManager) Delete(
 	ctx context.Context,
 	res acktypes.AWSResource,
-) error {
+) (acktypes.AWSResource, error) {
 	r := rm.concreteResource(res)
 	if r.ko == nil {
 		// Should never happen... if it does, it's buggy code.
@@ -166,6 +173,63 @@ func (rm *resourceManager) ARNFromName(name string) string {
 		rm.awsAccountID,
 		name,
 	)
+}
+
+// LateInitialize returns an acktypes.AWSResource after setting the late initialized
+// fields from the readOne call. This method will initialize the optional fields
+// which were not provided by the k8s user but were defaulted by the AWS service.
+// If there are no such fields to be initialized, the returned object is similar to
+// object passed in the parameter.
+func (rm *resourceManager) LateInitialize(
+	ctx context.Context,
+	latest acktypes.AWSResource,
+) (acktypes.AWSResource, error) {
+	rlog := ackrtlog.FromContext(ctx)
+	// If there are no fields to late initialize, do nothing
+	if len(lateInitializeFieldNames) == 0 {
+		rlog.Debug("no late initialization required.")
+		return latest, nil
+	}
+	lateInitConditionReason := ""
+	lateInitConditionMessage := ""
+	observed, err := rm.ReadOne(ctx, latest)
+	if err != nil {
+		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
+		lateInitConditionReason = "Late Initialization Failure"
+		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return latest, err
+	}
+	latest = rm.lateInitializeFromReadOneOutput(observed, latest)
+	incompleteInitialization := rm.incompleteLateInitialization(latest)
+	if incompleteInitialization {
+		// Add the condition with LateInitialized=False
+		lateInitConditionMessage = "Late initialization did not complete, requeuing with delay of 5 seconds"
+		lateInitConditionReason = "Delayed Late Initialization"
+		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return latest, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
+	}
+	// Set LateIntialized condition to True
+	lateInitConditionMessage = "Late initialization successful"
+	lateInitConditionReason = "Late initialization successful"
+	ackcondition.SetLateInitialized(latest, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
+	return latest, nil
+}
+
+// incompleteLateInitialization return true if there are fields which were supposed to be
+// late initialized but are not. If all the fields are late initialized, false is returned
+func (rm *resourceManager) incompleteLateInitialization(
+	latest acktypes.AWSResource,
+) bool {
+	return false
+}
+
+// lateInitializeFromReadOneOutput late initializes the 'latest' resource from the 'observed'
+// resource and returns 'latest' resource
+func (rm *resourceManager) lateInitializeFromReadOneOutput(
+	observed acktypes.AWSResource,
+	latest acktypes.AWSResource,
+) acktypes.AWSResource {
+	return latest
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/repository/resource.go
+++ b/pkg/resource/repository/resource.go
@@ -84,12 +84,22 @@ func (r *resource) SetObjectMeta(meta metav1.ObjectMeta) {
 	r.ko.ObjectMeta = meta
 }
 
+// SetStatus will set the Status field for the resource
+func (r *resource) SetStatus(desired acktypes.AWSResource) {
+	r.ko.Status = desired.(*resource).ko.Status
+}
+
 // SetIdentifiers sets the Spec or Status field that is referenced as the unique
 // resource identifier
 func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error {
-	if identifier.NameOrID == nil {
+	if identifier.NameOrID == "" {
 		return ackerrors.MissingNameIdentifier
 	}
-	r.ko.Spec.Name = identifier.NameOrID
+
+	f0, f0ok := identifier.AdditionalKeys["registryID"]
+	if f0ok {
+		r.ko.Status.RegistryID = &f0
+	}
+
 	return nil
 }


### PR DESCRIPTION
Updates the ACK runtime for ECR controller to v0.11.0, which brings in
lots of new features including LateInitialize, better delta handling,
better logging and corrected release artifact generation.

Note to reviewers: please check out the changes I made to
`pkg/resource/repository/custom_update_api.go`. I had to change the
`delta.DifferentAt` calls to reference `Spec.` and I added the common
resource logging traces into the sub-functions for handling the custom
update calls for repository attributes.

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.