### PR TITLE
update to ACK runtime v0.12.0

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2021-08-17T13:53:27Z"
-  build_hash: 64436ce7e8d7f7356daa6888600a68da4f09a5ac
+  build_date: "2021-08-18T01:08:52Z"
+  build_hash: 7ce2d042a4b94dab4e8d36f4b682071ab5ef148d
   go_version: go1.15.5 linux/amd64
-  version: v0.11.0
+  version: v0.12.0
 api_directory_checksum: 3c829828db77ef587929da78f41d52b2459fb054
 api_version: v1alpha1
 aws_sdk_go_version: v1.38.35
@@ -11,4 +11,4 @@ generator_config_info:
   original_file_name: generator.yaml
 last_modification:
   reason: API generation
-  timestamp: 2021-08-17 13:53:33.069703342 +0000 UTC
+  timestamp: 2021-08-18 01:08:58.260506939 +0000 UTC

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/ecr-controller
 go 1.14
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.11.0
+	github.com/aws-controllers-k8s/runtime v0.12.0
 	github.com/aws/aws-sdk-go v1.38.35
 	github.com/go-logr/logr v0.1.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws-controllers-k8s/runtime v0.11.0 h1:M8gSC6qs2yxLDRh75htYdal4lPf3Uodh0SKeiXSgPno=
 github.com/aws-controllers-k8s/runtime v0.11.0/go.mod h1:kG2WM4JAmLgf67cgZV9IZUkY2DsrUzsaNbmhFMfb05c=
+github.com/aws-controllers-k8s/runtime v0.12.0 h1:G/lCEozh4Brsv1Ojqyl9D/whpq/YvcFtDZBWXf6YIgI=
+github.com/aws-controllers-k8s/runtime v0.12.0/go.mod h1:kG2WM4JAmLgf67cgZV9IZUkY2DsrUzsaNbmhFMfb05c=
 github.com/aws/aws-sdk-go v1.37.10/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.38.35 h1:7AlAO0FC+8nFjxiGKEmq0QLpiA8/XFr6eIxgRTwkdTg=
 github.com/aws/aws-sdk-go v1.38.35/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=

--- a/pkg/resource/repository/sdk.go
+++ b/pkg/resource/repository/sdk.go
@@ -50,7 +50,6 @@ func (rm *resourceManager) sdkFind(
 	rlog := ackrtlog.FromContext(ctx)
 	exit := rlog.Trace("rm.sdkFind")
 	defer exit(err)
-
 	// If any required fields in the input shape are missing, AWS resource is
 	// not created yet. Return NotFound here to indicate to callers that the
 	// resource isn't yet created.


### PR DESCRIPTION
Bring in fix for existing resources and saving of metadata in adoption
reconciler.

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.