### PR TITLE
Update ACK runtime to 'v0.13.2'

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - core-ack-team
+  - service-team

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,11 @@
+# See the OWNERS docs at https://go.k8s.io/owners#owners_aliases
+
+aliases:
+  # Always allow the core ACK maintainers to have access to your repository
+  core-ack-team:
+    - jaypipes
+    - a-hilaly
+    - RedbackThomson
+    - vijtrip2
+  # TODO: Add your team members to your team controller alias
+  service-team: []

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,14 +1,14 @@
 ack_generate_info:
-  build_date: "2021-08-18T01:08:52Z"
-  build_hash: 7ce2d042a4b94dab4e8d36f4b682071ab5ef148d
-  go_version: go1.15.5 linux/amd64
-  version: v0.12.0
+  build_date: "2021-09-08T23:18:14Z"
+  build_hash: 394e8294aabf0b221c35f7a5c7bc7e4e43bc6f10
+  go_version: go1.14.1 darwin/amd64
+  version: v0.13.2
 api_directory_checksum: 3c829828db77ef587929da78f41d52b2459fb054
 api_version: v1alpha1
 aws_sdk_go_version: v1.38.35
 generator_config_info:
-  file_checksum: 8c4aaf877173015433fee1c3ecf67e23dc86be89
+  file_checksum: 72fbd31cdc7cf373e2007988cddc38fab773b3ae
   original_file_name: generator.yaml
 last_modification:
   reason: API generation
-  timestamp: 2021-08-18 01:08:58.260506939 +0000 UTC
+  timestamp: 2021-09-08 23:18:28.502316 +0000 UTC

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -1,3 +1,6 @@
+operations:
+  DescribeRepositories:
+    primary_identifier_field_name: Name
 resources:
   Repository:
     renames:

--- a/generator.yaml
+++ b/generator.yaml
@@ -1,3 +1,6 @@
+operations:
+  DescribeRepositories:
+    primary_identifier_field_name: Name
 resources:
   Repository:
     renames:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/ecr-controller
 go 1.14
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.12.0
+	github.com/aws-controllers-k8s/runtime v0.13.2
 	github.com/aws/aws-sdk-go v1.38.35
 	github.com/go-logr/logr v0.1.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -23,10 +23,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/runtime v0.11.0 h1:M8gSC6qs2yxLDRh75htYdal4lPf3Uodh0SKeiXSgPno=
-github.com/aws-controllers-k8s/runtime v0.11.0/go.mod h1:kG2WM4JAmLgf67cgZV9IZUkY2DsrUzsaNbmhFMfb05c=
-github.com/aws-controllers-k8s/runtime v0.12.0 h1:G/lCEozh4Brsv1Ojqyl9D/whpq/YvcFtDZBWXf6YIgI=
-github.com/aws-controllers-k8s/runtime v0.12.0/go.mod h1:kG2WM4JAmLgf67cgZV9IZUkY2DsrUzsaNbmhFMfb05c=
+github.com/aws-controllers-k8s/runtime v0.13.2 h1:+gVwW4dTndPb4lB0WNLdHeiP7AGBOV+wBHGjpQUOh+w=
+github.com/aws-controllers-k8s/runtime v0.13.2/go.mod h1:kG2WM4JAmLgf67cgZV9IZUkY2DsrUzsaNbmhFMfb05c=
 github.com/aws/aws-sdk-go v1.37.10/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.38.35 h1:7AlAO0FC+8nFjxiGKEmq0QLpiA8/XFr6eIxgRTwkdTg=
 github.com/aws/aws-sdk-go v1.38.35/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ecr-chart
-description: A Helm chart for the ACK service controller for ecr
+description: A Helm chart for the ACK service controller for Amazon Elastic Container Registry (ECR)
 version: v0.0.7
 appVersion: v0.0.7
 home: https://github.com/aws-controllers-k8s/ecr-controller
@@ -10,7 +10,7 @@ sources:
 maintainers:
   - name: ACK Admins
     url: https://github.com/orgs/aws-controllers-k8s/teams/ack-admin
-  - name: ecr Admins
+  - name: ECR Admins
     url: https://github.com/orgs/aws-controllers-k8s/teams/ecr-maintainer
 keywords:
   - aws

--- a/pkg/resource/repository/delta.go
+++ b/pkg/resource/repository/delta.go
@@ -16,6 +16,7 @@
 package repository
 
 import (
+	"bytes"
 	"reflect"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
@@ -23,6 +24,7 @@ import (
 
 // Hack to avoid import errors during build...
 var (
+	_ = &bytes.Buffer{}
 	_ = &reflect.Method{}
 )
 

--- a/pkg/resource/repository/manager.go
+++ b/pkg/resource/repository/manager.go
@@ -159,7 +159,15 @@ func (rm *resourceManager) Delete(
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	return rm.sdkDelete(ctx, r)
+	observed, err := rm.sdkDelete(ctx, r)
+	if err != nil {
+		if observed != nil {
+			return rm.onError(observed, err)
+		}
+		return rm.onError(r, err)
+	}
+
+	return rm.onSuccess(observed)
 }
 
 // ARNFromName returns an AWS Resource Name from a given string name. This
@@ -190,35 +198,36 @@ func (rm *resourceManager) LateInitialize(
 		rlog.Debug("no late initialization required.")
 		return latest, nil
 	}
+	latestCopy := latest.DeepCopy()
 	lateInitConditionReason := ""
 	lateInitConditionMessage := ""
-	observed, err := rm.ReadOne(ctx, latest)
+	observed, err := rm.ReadOne(ctx, latestCopy)
 	if err != nil {
 		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
 		lateInitConditionReason = "Late Initialization Failure"
-		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
-		return latest, err
+		ackcondition.SetLateInitialized(latestCopy, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return latestCopy, err
 	}
-	latest = rm.lateInitializeFromReadOneOutput(observed, latest)
-	incompleteInitialization := rm.incompleteLateInitialization(latest)
+	lateInitializedRes := rm.lateInitializeFromReadOneOutput(observed, latestCopy)
+	incompleteInitialization := rm.incompleteLateInitialization(lateInitializedRes)
 	if incompleteInitialization {
 		// Add the condition with LateInitialized=False
 		lateInitConditionMessage = "Late initialization did not complete, requeuing with delay of 5 seconds"
 		lateInitConditionReason = "Delayed Late Initialization"
-		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
-		return latest, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
+		ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return lateInitializedRes, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
 	}
-	// Set LateIntialized condition to True
+	// Set LateInitialized condition to True
 	lateInitConditionMessage = "Late initialization successful"
 	lateInitConditionReason = "Late initialization successful"
-	ackcondition.SetLateInitialized(latest, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
-	return latest, nil
+	ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
+	return lateInitializedRes, nil
 }
 
 // incompleteLateInitialization return true if there are fields which were supposed to be
 // late initialized but are not. If all the fields are late initialized, false is returned
 func (rm *resourceManager) incompleteLateInitialization(
-	latest acktypes.AWSResource,
+	res acktypes.AWSResource,
 ) bool {
 	return false
 }
@@ -261,6 +270,9 @@ func (rm *resourceManager) onError(
 	r *resource,
 	err error,
 ) (acktypes.AWSResource, error) {
+	if ackcompare.IsNil(r) {
+		return nil, err
+	}
 	r1, updated := rm.updateConditions(r, false, err)
 	if !updated {
 		return r, err
@@ -281,6 +293,9 @@ func (rm *resourceManager) onError(
 func (rm *resourceManager) onSuccess(
 	r *resource,
 ) (acktypes.AWSResource, error) {
+	if ackcompare.IsNil(r) {
+		return nil, nil
+	}
 	r1, updated := rm.updateConditions(r, true, nil)
 	if !updated {
 		return r, nil

--- a/pkg/resource/repository/resource.go
+++ b/pkg/resource/repository/resource.go
@@ -59,7 +59,7 @@ func (r *resource) RuntimeObject() k8srt.Object {
 // MetaObject returns the Kubernetes apimachinery/apis/meta/v1.Object
 // representation of the AWSResource
 func (r *resource) MetaObject() metav1.Object {
-	return r.ko
+	return r.ko.GetObjectMeta()
 }
 
 // RuntimeMetaObject returns an object that implements both the Kubernetes
@@ -96,10 +96,16 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 		return ackerrors.MissingNameIdentifier
 	}
 
-	f0, f0ok := identifier.AdditionalKeys["registryID"]
-	if f0ok {
-		r.ko.Status.RegistryID = &f0
+	f2, f2ok := identifier.AdditionalKeys["registryID"]
+	if f2ok {
+		r.ko.Status.RegistryID = &f2
 	}
 
 	return nil
+}
+
+// DeepCopy will return a copy of the resource
+func (r *resource) DeepCopy() acktypes.AWSResource {
+	koCopy := r.ko.DeepCopy()
+	return &resource{koCopy}
 }

--- a/pkg/resource/repository/sdk.go
+++ b/pkg/resource/repository/sdk.go
@@ -402,7 +402,7 @@ func (rm *resourceManager) updateConditions(
 			errorMessage = err.Error()
 		} else {
 			awsErr, _ := ackerr.AWSError(err)
-			errorMessage = awsErr.Message()
+			errorMessage = awsErr.Error()
 		}
 		terminalCondition.Status = corev1.ConditionTrue
 		terminalCondition.Message = &errorMessage
@@ -425,7 +425,7 @@ func (rm *resourceManager) updateConditions(
 			awsErr, _ := ackerr.AWSError(err)
 			errorMessage := err.Error()
 			if awsErr != nil {
-				errorMessage = awsErr.Message()
+				errorMessage = awsErr.Error()
 			}
 			recoverableCondition.Message = &errorMessage
 		} else if recoverableCondition != nil {


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/940

Description of changes:
* Generating ecr controller with ACK runtime v0.13.2
* Auto generation failed because it needed `generator.yaml` updates

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
