### PR TITLE
Add `LifecyclePolicy` field to `Repository`

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2021-10-27T21:20:07Z"
-  build_hash: d2b063806d25cfcae4f2d4eb44f8e3f713b23e8e
-  go_version: go1.15
+  build_date: "2021-11-16T14:08:50Z"
+  build_hash: ff5700c3e093082af2cbb53a461acb94ab1674d9
+  go_version: go1.16.4
   version: v0.15.2
-api_directory_checksum: 3c829828db77ef587929da78f41d52b2459fb054
+api_directory_checksum: aa86a638fe9bbdb47b2f0cad0e82abafcff8571e
 api_version: v1alpha1
 aws_sdk_go_version: v1.38.35
 generator_config_info:
-  file_checksum: b271840866f91cb16dbad00532c85716620cbbee
+  file_checksum: 746fd9f662f685e64ba766c60ac6c5bb5eea7524
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -7,6 +7,10 @@ resources:
         from:
           operation: CreateRepository
           path: RepositoryName
+      LifecyclePolicy:
+        from:
+          operation: PutLifecyclePolicy
+          path: LifecyclePolicyText
     renames:
       operations:
         CreateRepository:
@@ -25,5 +29,8 @@ resources:
     list_operation:
       match_fields:
         - Name
+    hooks:
+      sdk_read_many_post_set_output:
+        template_path: hooks/repository/sdk_read_many_post_set_output.go.tpl
     update_operation:
       custom_method_name: customUpdateRepository

--- a/apis/v1alpha1/repository.go
+++ b/apis/v1alpha1/repository.go
@@ -35,6 +35,8 @@ type RepositorySpec struct {
 	// be overwritten. If IMMUTABLE is specified, all image tags within the repository
 	// will be immutable which will prevent them from being overwritten.
 	ImageTagMutability *string `json:"imageTagMutability,omitempty"`
+	// The JSON repository policy text to apply to the repository.
+	LifecyclePolicy *string `json:"lifecyclePolicy,omitempty"`
 	// The name to use for the repository. The repository name may be specified
 	// on its own (such as nginx-web-app) or it can be prepended with a namespace
 	// to group the repository into a category (such as project-a/nginx-web-app).

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -236,6 +236,11 @@ func (in *RepositorySpec) DeepCopyInto(out *RepositorySpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.LifecyclePolicy != nil {
+		in, out := &in.LifecyclePolicy, &out.LifecyclePolicy
+		*out = new(string)
+		**out = **in
+	}
 	if in.Name != nil {
 		in, out := &in.Name, &out.Name
 		*out = new(string)

--- a/config/crd/bases/ecr.services.k8s.aws_repositories.yaml
+++ b/config/crd/bases/ecr.services.k8s.aws_repositories.yaml
@@ -62,6 +62,9 @@ spec:
                   all image tags within the repository will be immutable which will
                   prevent them from being overwritten.
                 type: string
+              lifecyclePolicy:
+                description: The JSON repository policy text to apply to the repository.
+                type: string
               name:
                 description: The name to use for the repository. The repository name
                   may be specified on its own (such as nginx-web-app) or it can be

--- a/generator.yaml
+++ b/generator.yaml
@@ -7,6 +7,10 @@ resources:
         from:
           operation: CreateRepository
           path: RepositoryName
+      LifecyclePolicy:
+        from:
+          operation: PutLifecyclePolicy
+          path: LifecyclePolicyText
     renames:
       operations:
         CreateRepository:
@@ -25,5 +29,8 @@ resources:
     list_operation:
       match_fields:
         - Name
+    hooks:
+      sdk_read_many_post_set_output:
+        template_path: hooks/repository/sdk_read_many_post_set_output.go.tpl
     update_operation:
       custom_method_name: customUpdateRepository

--- a/helm/crds/ecr.services.k8s.aws_repositories.yaml
+++ b/helm/crds/ecr.services.k8s.aws_repositories.yaml
@@ -62,6 +62,9 @@ spec:
                   all image tags within the repository will be immutable which will
                   prevent them from being overwritten.
                 type: string
+              lifecyclePolicy:
+                description: The JSON repository policy text to apply to the repository.
+                type: string
               name:
                 description: The name to use for the repository. The repository name
                   may be specified on its own (such as nginx-web-app) or it can be

--- a/pkg/resource/repository/delta.go
+++ b/pkg/resource/repository/delta.go
@@ -77,6 +77,13 @@ func newResourceDelta(
 			delta.Add("Spec.ImageTagMutability", a.ko.Spec.ImageTagMutability, b.ko.Spec.ImageTagMutability)
 		}
 	}
+	if ackcompare.HasNilDifference(a.ko.Spec.LifecyclePolicy, b.ko.Spec.LifecyclePolicy) {
+		delta.Add("Spec.LifecyclePolicy", a.ko.Spec.LifecyclePolicy, b.ko.Spec.LifecyclePolicy)
+	} else if a.ko.Spec.LifecyclePolicy != nil && b.ko.Spec.LifecyclePolicy != nil {
+		if *a.ko.Spec.LifecyclePolicy != *b.ko.Spec.LifecyclePolicy {
+			delta.Add("Spec.LifecyclePolicy", a.ko.Spec.LifecyclePolicy, b.ko.Spec.LifecyclePolicy)
+		}
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Name, b.ko.Spec.Name) {
 		delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
 	} else if a.ko.Spec.Name != nil && b.ko.Spec.Name != nil {

--- a/pkg/resource/repository/hook.go
+++ b/pkg/resource/repository/hook.go
@@ -1,0 +1,32 @@
+package repository
+
+import (
+	"context"
+
+	svcapitypes "github.com/aws-controllers-k8s/ecr-controller/apis/v1alpha1"
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
+	svcsdk "github.com/aws/aws-sdk-go/service/ecr"
+)
+
+// setResourceAdditionalFields will describe the fields that are not return by
+// DescribeRepository calls
+func (rm *resourceManager) setResourceAdditionalFields(
+	ctx context.Context,
+	r *resource,
+	ko *svcapitypes.Repository,
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.setResourceAdditionalFields")
+	defer exit(err)
+
+	getLifecyclePolicyResponse, err := rm.sdkapi.GetLifecyclePolicyWithContext(
+		ctx,
+		&svcsdk.GetLifecyclePolicyInput{
+			RepositoryName: r.ko.Spec.Name,
+			RegistryId:     r.ko.Status.RegistryID,
+		},
+	)
+	rm.metrics.RecordAPICall("GET", "GetLifecyclePolicy", err)
+	ko.Spec.LifecyclePolicy = getLifecyclePolicyResponse.LifecyclePolicyText
+	return nil
+}

--- a/pkg/resource/repository/sdk.go
+++ b/pkg/resource/repository/sdk.go
@@ -147,6 +147,9 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
+	if err := rm.setResourceAdditionalFields(ctx, r, ko); err != nil {
+		return nil, err
+	}
 	return &resource{ko}, nil
 }
 

--- a/templates/hooks/repository/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/repository/sdk_read_many_post_set_output.go.tpl
@@ -1,0 +1,3 @@
+	if err := rm.setResourceAdditionalFields(ctx, r, ko); err != nil {
+		return nil, err
+	}

--- a/test/e2e/resources/repository_lifecycle_policy.yaml
+++ b/test/e2e/resources/repository_lifecycle_policy.yaml
@@ -1,0 +1,10 @@
+apiVersion: ecr.services.k8s.aws/v1alpha1
+kind: Repository
+metadata:
+  name: $REPOSITORY_NAME
+spec:
+  name: $REPOSITORY_NAME
+  imageScanningConfiguration:
+    scanOnPush: false
+  imageTagMutability: MUTABLE
+  lifecyclePolicy: '{"rules":[{"rulePriority":1,"description":"Expire images older than 14 days","selection":{"tagStatus":"untagged","countType":"sinceImagePushed","countUnit":"days","countNumber":14},"action":{"type":"expire"}}]}'


### PR DESCRIPTION
https://github.com/aws-controllers-k8s/community/issues/1043

Description of changes:
- Add `LifecyclePolicy` field to `Repository` resource
- e2e tests for updates or creation of repositories with lifecycle policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
