### PR TITLE
Add update code path for repository tags

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -7,7 +7,7 @@ api_directory_checksum: deb6d526537cf2d0a956eb58ceeb430de3eddab5
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: 746fd9f662f685e64ba766c60ac6c5bb5eea7524
+  file_checksum: d892d4b976d5d677ce3837d86b5256f7ee89a9e3
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -11,6 +11,9 @@ resources:
         from:
           operation: PutLifecyclePolicy
           path: LifecyclePolicyText
+      Tags:
+        compare:
+          is_ignored: true
     renames:
       operations:
         CreateRepository:
@@ -30,6 +33,8 @@ resources:
       match_fields:
         - Name
     hooks:
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
       sdk_read_many_post_set_output:
         template_path: hooks/repository/sdk_read_many_post_set_output.go.tpl
     update_operation:

--- a/generator.yaml
+++ b/generator.yaml
@@ -11,6 +11,9 @@ resources:
         from:
           operation: PutLifecyclePolicy
           path: LifecyclePolicyText
+      Tags:
+        compare:
+          is_ignored: true
     renames:
       operations:
         CreateRepository:
@@ -30,6 +33,8 @@ resources:
       match_fields:
         - Name
     hooks:
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
       sdk_read_many_post_set_output:
         template_path: hooks/repository/sdk_read_many_post_set_output.go.tpl
     update_operation:

--- a/pkg/resource/repository/delta.go
+++ b/pkg/resource/repository/delta.go
@@ -40,6 +40,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	customPreCompare(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.EncryptionConfiguration, b.ko.Spec.EncryptionConfiguration) {
 		delta.Add("Spec.EncryptionConfiguration", a.ko.Spec.EncryptionConfiguration, b.ko.Spec.EncryptionConfiguration)
@@ -97,9 +98,6 @@ func newResourceDelta(
 		if *a.ko.Spec.RegistryID != *b.ko.Spec.RegistryID {
 			delta.Add("Spec.RegistryID", a.ko.Spec.RegistryID, b.ko.Spec.RegistryID)
 		}
-	}
-	if !reflect.DeepEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 
 	return delta

--- a/pkg/resource/repository/hook.go
+++ b/pkg/resource/repository/hook.go
@@ -3,10 +3,14 @@ package repository
 import (
 	"context"
 
-	svcapitypes "github.com/aws-controllers-k8s/ecr-controller/apis/v1alpha1"
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
+	ackutil "github.com/aws-controllers-k8s/runtime/pkg/util"
 	svcsdk "github.com/aws/aws-sdk-go/service/ecr"
+
+	"github.com/aws-controllers-k8s/ecr-controller/apis/v1alpha1"
+	svcapitypes "github.com/aws-controllers-k8s/ecr-controller/apis/v1alpha1"
 )
 
 // setResourceAdditionalFields will describe the fields that are not return by
@@ -29,14 +33,113 @@ func (rm *resourceManager) setResourceAdditionalFields(
 	)
 	rm.metrics.RecordAPICall("GET", "GetLifecyclePolicy", err)
 	if err != nil {
-		if awsErr, ok := ackerr.AWSError(err); ok && awsErr.Code() == svcsdk.ErrCodeLifecyclePolicyNotFoundException {
-			ko.Spec.LifecyclePolicy = nil
-			return nil
+		if awsErr, ok := ackerr.AWSError(err); !ok || awsErr.Code() != svcsdk.ErrCodeLifecyclePolicyNotFoundException {
+			return err
 		}
-		return err
+		ko.Spec.LifecyclePolicy = nil
 	}
 	if getLifecyclePolicyResponse.LifecyclePolicyText != nil {
 		ko.Spec.LifecyclePolicy = getLifecyclePolicyResponse.LifecyclePolicyText
 	}
+
+	ko.Spec.Tags, err = rm.getRepositoryTags(ctx, string(*ko.Status.ACKResourceMetadata.ARN))
+	rm.metrics.RecordAPICall("GET", "ListTagsForResource", err)
+	if err != nil {
+		return err
+	}
+
 	return nil
+}
+
+func (rm *resourceManager) getRepositoryTags(ctx context.Context, resourceARN string) ([]*v1alpha1.Tag, error) {
+	listTagsForResourceResponse, err := rm.sdkapi.ListTagsForResourceWithContext(
+		ctx,
+		&svcsdk.ListTagsForResourceInput{
+			ResourceArn: &resourceARN,
+		},
+	)
+	rm.metrics.RecordAPICall("GET", "ListTagsForResource", err)
+	if err != nil {
+		return nil, err
+	}
+	tags := make([]*v1alpha1.Tag, 0, len(listTagsForResourceResponse.Tags))
+	for _, tag := range listTagsForResourceResponse.Tags {
+		tags = append(tags, &v1alpha1.Tag{
+			Key:   tag.Key,
+			Value: tag.Value,
+		})
+	}
+	return tags, nil
+}
+
+func customPreCompare(
+	delta *ackcompare.Delta,
+	a *resource,
+	b *resource,
+) {
+	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+	} else if len(a.ko.Spec.Tags) > 0 {
+		if !equalTags(a.ko.Spec.Tags, b.ko.Spec.Tags) {
+			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+		}
+	}
+}
+
+// equalTags returns true if two Tag arrays are equal regardless of the order
+// of their elements.
+func equalTags(
+	a []*v1alpha1.Tag,
+	b []*v1alpha1.Tag,
+) bool {
+	added, updated, removed := computeTagsDelta(a, b)
+	return len(added) == 0 && len(updated) == 0 && len(removed) == 0
+}
+
+// computeTagsDelta compares two Tag arrays and return three different list
+// containing the added, updated and removed tags.
+// The removed tags only contains the Key of tags
+func computeTagsDelta(
+	a []*v1alpha1.Tag,
+	b []*v1alpha1.Tag,
+) (added, updated []*v1alpha1.Tag, removed []*string) {
+	var visitedIndexes []string
+mainLoop:
+	for _, aElement := range a {
+		visitedIndexes = append(visitedIndexes, *aElement.Key)
+		for _, bElement := range b {
+			if equalStrings(aElement.Key, bElement.Key) {
+				if !equalStrings(aElement.Value, bElement.Value) {
+					updated = append(updated, bElement)
+				}
+				continue mainLoop
+			}
+		}
+		removed = append(removed, aElement.Key)
+	}
+	for _, bElement := range b {
+		if !ackutil.InStrings(*bElement.Key, visitedIndexes) {
+			added = append(added, bElement)
+		}
+	}
+	return added, updated, removed
+}
+
+// svcTagsFromResourceTags transforms a *v1alpha1.Tag array to a *svcsdk.Tag array.
+func sdkTagsFromResourceTags(rTags []*v1alpha1.Tag) []*svcsdk.Tag {
+	tags := make([]*svcsdk.Tag, len(rTags))
+	for i := range rTags {
+		tags[i] = &svcsdk.Tag{
+			Key:   rTags[i].Key,
+			Value: rTags[i].Value,
+		}
+	}
+	return tags
+}
+
+func equalStrings(a, b *string) bool {
+	if a == nil {
+		return b == nil || *b == ""
+	}
+	return (*a == "" && b == nil) || *a == *b
 }

--- a/test/e2e/tests/test_repository.py
+++ b/test/e2e/tests/test_repository.py
@@ -71,6 +71,16 @@ class TestRepository:
             logging.debug(e)
             return ""
 
+    def get_resource_tags(self, ecr_client, resource_arn: str):
+        try:
+            resp = ecr_client.list_tags_for_resource(
+                resourceArn=resource_arn
+            )
+            return resp['tags']
+        except Exception as e:
+            logging.debug(e)
+            return None
+
     def repository_exists(self, ecr_client, repository_name: str) -> bool:
         return self.get_repository(ecr_client, repository_name) is not None
 
@@ -167,6 +177,109 @@ class TestRepository:
 
         lifecycle_policy = self.get_lifecycle_policy(ecr_client, resource_name, repo["registryId"])
         assert lifecycle_policy == ""
+
+        # Delete k8s resource
+        _, deleted = k8s.delete_custom_resource(ref)
+        assert deleted is True
+
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+
+        # Check ECR repository doesn't exists
+        exists = self.repository_exists(ecr_client, resource_name)
+        assert not exists
+
+    def test_repository_tags(self, ecr_client):
+        resource_name = random_suffix_name("ecr-repository", 24)
+
+        replacements = REPLACEMENT_VALUES.copy()
+        replacements["REPOSITORY_NAME"] = resource_name
+        # Load ECR CR
+        resource_data = load_ecr_resource(
+            "repository",
+            additional_replacements=replacements,
+        )
+        logging.debug(resource_data)
+
+        # Create k8s resource
+        ref = k8s.CustomResourceReference(
+            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+            resource_name, namespace="default",
+        )
+        k8s.create_custom_resource(ref, resource_data)
+        cr = k8s.wait_resource_consumed_by_controller(ref)
+
+        assert cr is not None
+        assert k8s.get_resource_exists(ref)
+
+        time.sleep(CREATE_WAIT_AFTER_SECONDS)
+
+        cr = k8s.wait_resource_consumed_by_controller(ref)
+
+        # Check ECR repository exists
+        exists = self.repository_exists(ecr_client, resource_name)
+        assert exists
+
+        # Add respository tags
+        tags = [
+            {
+                "key": "k1",
+                "value": "v1",
+            },
+            {
+                "key": "k2",
+                "value": "v2",
+            },
+        ]
+        cr["spec"]["tags"] = tags
+
+        # Patch k8s resource
+        k8s.patch_custom_resource(ref, cr)
+        time.sleep(UPDATE_WAIT_AFTER_SECONDS)
+
+        repository_tags = self.get_resource_tags(ecr_client, cr["status"]["ackResourceMetadata"]["arn"])
+        assert len(repository_tags) == len(tags)
+        assert repository_tags[0]['Key'] == tags[0]['key']
+        assert repository_tags[0]['Value'] == tags[0]['value']
+        assert repository_tags[1]['Key'] == tags[1]['key']
+        assert repository_tags[1]['Value'] == tags[1]['value']
+
+        
+        # Update repository tags
+        tags = [
+            {
+                "key": "k1",
+                "value": "v1",
+            },
+            {
+                "key": "k2",
+                "value": "v2.updated",
+            },
+        ]
+
+        cr = k8s.wait_resource_consumed_by_controller(ref)
+        cr["spec"]["tags"] = tags
+        k8s.patch_custom_resource(ref, cr)
+
+        time.sleep(UPDATE_WAIT_AFTER_SECONDS)
+
+        repository_tags = self.get_resource_tags(ecr_client, cr["status"]["ackResourceMetadata"]["arn"])
+        assert len(repository_tags) == len(tags)
+        assert repository_tags[0]['Key'] == tags[0]['key']
+        assert repository_tags[0]['Value'] == tags[0]['value']
+        assert repository_tags[1]['Key'] == tags[1]['key']
+        assert repository_tags[1]['Value'] == tags[1]['value']
+
+        cr = k8s.wait_resource_consumed_by_controller(ref)
+
+        # Delete one repository tag
+        cr["spec"]["tags"] = tags[:-1]
+        k8s.patch_custom_resource(ref, cr)
+        time.sleep(UPDATE_WAIT_AFTER_SECONDS)
+
+        repository_tags = self.get_resource_tags(ecr_client, cr["status"]["ackResourceMetadata"]["arn"])
+        assert len(repository_tags) == len(tags[:-1])
+        assert repository_tags[0]['Key'] == tags[0]['key']
+        assert repository_tags[0]['Value'] == tags[0]['value']
 
         # Delete k8s resource
         _, deleted = k8s.delete_custom_resource(ref)


### PR DESCRIPTION
Issue https://github.com/aws-controllers-k8s/community/issues/1137

Description of changes:
Add update code path for ECR repositories
- Regenerate controller with the code-gen latest commit
- Add custom hooks for tags comparison and update code path
- Add e2e tests for repository tags update

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
