### PR TITLE
Late initialize `RegistryID` field of Repository spec

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-03-25T18:23:50Z"
+  build_date: "2022-03-25T20:20:13Z"
   build_hash: c6b852a8017aa73cfc5a882b1ba60c88d820e967
-  go_version: go1.17.5
+  go_version: go1.17.6
   version: v0.18.1
 api_directory_checksum: deb6d526537cf2d0a956eb58ceeb430de3eddab5
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: d892d4b976d5d677ce3837d86b5256f7ee89a9e3
+  file_checksum: 23214d18e53be1516c6f0a3a2cc870e647e3c305
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -14,6 +14,8 @@ resources:
       Tags:
         compare:
           is_ignored: true
+      RegistryID:
+        late_initialize: {}
     renames:
       operations:
         CreateRepository:

--- a/generator.yaml
+++ b/generator.yaml
@@ -14,6 +14,8 @@ resources:
       Tags:
         compare:
           is_ignored: true
+      RegistryID:
+        late_initialize: {}
     renames:
       operations:
         CreateRepository:


### PR DESCRIPTION
Description of changes:

While running soak tests and local e2e tests, we observed some very
rare runtime panics during resource reconciliation when the update
code path is triggered. The reason was due to the controller trying
to access a nil value of `RegistryID`.
This specific case happened whenever the ECR DescribeRepository API call
returned a NotFound error right after creating a repository. This chain
of events causes the controller to not populate the `RegistryID`, hence
the nil pointer runtime panics during the update code path.

This patch late initialize the `RegistryID` field to prevent the runtime
panic describe above.
By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
