### PR TITLE
Add support for `Repository` Policy

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-04-15T17:17:20Z"
-  build_hash: 50c64871bcaf88b9ee200eb8d6b8245fa8f675eb
-  go_version: go1.17.5
-  version: v0.18.4
-api_directory_checksum: deb6d526537cf2d0a956eb58ceeb430de3eddab5
+  build_date: "2022-04-20T20:24:26Z"
+  build_hash: ec6a51dc81164f0ee81c10e403bef9c00571384a
+  go_version: go1.17.6
+  version: v0.18.4-1-gec6a51d
+api_directory_checksum: eb0e738ff4033343e16d5f30accb673360632793
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: 23214d18e53be1516c6f0a3a2cc870e647e3c305
+  file_checksum: 0d4da9376313edcb86631a3fdfebc2db0f795a2d
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -11,6 +11,10 @@ resources:
         from:
           operation: PutLifecyclePolicy
           path: LifecyclePolicyText
+      Policy:
+        from:
+          operation: SetRepositoryPolicy
+          path: PolicyText
       Tags:
         compare:
           is_ignored: true

--- a/apis/v1alpha1/repository.go
+++ b/apis/v1alpha1/repository.go
@@ -42,6 +42,10 @@ type RepositorySpec struct {
 	// to group the repository into a category (such as project-a/nginx-web-app).
 	// +kubebuilder:validation:Required
 	Name *string `json:"name"`
+	// The JSON repository policy text to apply to the repository. For more information,
+	// see Amazon ECR repository policies (https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-policy-examples.html)
+	// in the Amazon Elastic Container Registry User Guide.
+	Policy *string `json:"policy,omitempty"`
 	// The AWS account ID associated with the registry to create the repository.
 	// If you do not specify a registry, the default registry is assumed.
 	RegistryID *string `json:"registryID,omitempty"`

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -267,6 +267,11 @@ func (in *RepositorySpec) DeepCopyInto(out *RepositorySpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Policy != nil {
+		in, out := &in.Policy, &out.Policy
+		*out = new(string)
+		**out = **in
+	}
 	if in.RegistryID != nil {
 		in, out := &in.RegistryID, &out.RegistryID
 		*out = new(string)

--- a/config/crd/bases/ecr.services.k8s.aws_repositories.yaml
+++ b/config/crd/bases/ecr.services.k8s.aws_repositories.yaml
@@ -71,6 +71,11 @@ spec:
                   prepended with a namespace to group the repository into a category
                   (such as project-a/nginx-web-app).
                 type: string
+              policy:
+                description: The JSON repository policy text to apply to the repository.
+                  For more information, see Amazon ECR repository policies (https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-policy-examples.html)
+                  in the Amazon Elastic Container Registry User Guide.
+                type: string
               registryID:
                 description: The AWS account ID associated with the registry to create
                   the repository. If you do not specify a registry, the default registry

--- a/generator.yaml
+++ b/generator.yaml
@@ -11,6 +11,10 @@ resources:
         from:
           operation: PutLifecyclePolicy
           path: LifecyclePolicyText
+      Policy:
+        from:
+          operation: SetRepositoryPolicy
+          path: PolicyText
       Tags:
         compare:
           is_ignored: true

--- a/helm/crds/ecr.services.k8s.aws_repositories.yaml
+++ b/helm/crds/ecr.services.k8s.aws_repositories.yaml
@@ -71,6 +71,11 @@ spec:
                   prepended with a namespace to group the repository into a category
                   (such as project-a/nginx-web-app).
                 type: string
+              policy:
+                description: The JSON repository policy text to apply to the repository.
+                  For more information, see Amazon ECR repository policies (https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-policy-examples.html)
+                  in the Amazon Elastic Container Registry User Guide.
+                type: string
               registryID:
                 description: The AWS account ID associated with the registry to create
                   the repository. If you do not specify a registry, the default registry

--- a/pkg/resource/repository/delta.go
+++ b/pkg/resource/repository/delta.go
@@ -92,6 +92,13 @@ func newResourceDelta(
 			delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
 		}
 	}
+	if ackcompare.HasNilDifference(a.ko.Spec.Policy, b.ko.Spec.Policy) {
+		delta.Add("Spec.Policy", a.ko.Spec.Policy, b.ko.Spec.Policy)
+	} else if a.ko.Spec.Policy != nil && b.ko.Spec.Policy != nil {
+		if *a.ko.Spec.Policy != *b.ko.Spec.Policy {
+			delta.Add("Spec.Policy", a.ko.Spec.Policy, b.ko.Spec.Policy)
+		}
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.RegistryID, b.ko.Spec.RegistryID) {
 		delta.Add("Spec.RegistryID", a.ko.Spec.RegistryID, b.ko.Spec.RegistryID)
 	} else if a.ko.Spec.RegistryID != nil && b.ko.Spec.RegistryID != nil {

--- a/test/e2e/resources/repository_policy.yaml
+++ b/test/e2e/resources/repository_policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: ecr.services.k8s.aws/v1alpha1
+kind: Repository
+metadata:
+  name: $REPOSITORY_NAME
+spec:
+  name: $REPOSITORY_NAME
+  policy: '$REPOSITORY_POLICY'


### PR DESCRIPTION
Issue: https://github.com/aws-controllers-k8s/community/issues/582

Description of changes:
- Added a new field named `Policy `to the `Repository` CRD (from the
`SetRepositoryPolicy` API Call.
- Add e2e tests for CRUD operations on the `Policy` field
- Refactor `setAddtionalFields` hook function
- Fix some e2e rare error appearing when trying to patch an outdated CR

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
