### PR TITLE
feat: allow deletion of non-empty repos

### DIFF
--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -52,6 +52,8 @@ resources:
         code: customPreCompare(delta, a, b)
       sdk_read_many_post_set_output:
         template_path: hooks/repository/sdk_read_many_post_set_output.go.tpl
+      sdk_delete_post_build_request:
+        template_path: hooks/repository/sdk_delete_post_build_request.go.tpl
     update_operation:
       custom_method_name: customUpdateRepository
   PullThroughCacheRule:

--- a/generator.yaml
+++ b/generator.yaml
@@ -52,6 +52,8 @@ resources:
         code: customPreCompare(delta, a, b)
       sdk_read_many_post_set_output:
         template_path: hooks/repository/sdk_read_many_post_set_output.go.tpl
+      sdk_delete_post_build_request:
+        template_path: hooks/repository/sdk_delete_post_build_request.go.tpl
     update_operation:
       custom_method_name: customUpdateRepository
   PullThroughCacheRule:

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go v1.44.93
 	github.com/go-logr/logr v1.2.3
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.8.0
 	k8s.io/api v0.26.8
 	k8s.io/apimachinery v0.26.8
 	k8s.io/client-go v0.26.8
@@ -45,6 +46,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -274,13 +274,16 @@ github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0 h1:M2gUjqZET1qApGOWNSnZ49BAIMX4F/1plDv3+l31EJ4=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/resource/repository/hook_test.go
+++ b/pkg/resource/repository/hook_test.go
@@ -1,0 +1,44 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package repository_test
+
+import (
+	"testing"
+
+	repo "github.com/aws-controllers-k8s/ecr-controller/pkg/resource/repository"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_GetDeleteForce(t *testing.T) {
+	assert := assert.New(t)
+
+	noAnnotation := metav1.ObjectMeta{
+		Annotations: map[string]string{},
+	}
+	badAnnotation := metav1.ObjectMeta{
+		Annotations: map[string]string{
+			repo.AnnotationDeleteForce: "not-a-bool",
+		},
+	}
+	validAnnotation := metav1.ObjectMeta{
+		Annotations: map[string]string{
+			repo.AnnotationDeleteForce: "true",
+		},
+	}
+
+	assert.Equal(repo.GetDeleteForce(&noAnnotation), repo.DefaultDeleteForce)
+	assert.Equal(repo.GetDeleteForce(&badAnnotation), repo.DefaultDeleteForce)
+	assert.Equal(repo.GetDeleteForce(&validAnnotation), true)
+}

--- a/pkg/resource/repository/sdk.go
+++ b/pkg/resource/repository/sdk.go
@@ -352,6 +352,7 @@ func (rm *resourceManager) sdkDelete(
 	if err != nil {
 		return nil, err
 	}
+	input.SetForce(GetDeleteForce(&r.ko.ObjectMeta))
 	var resp *svcsdk.DeleteRepositoryOutput
 	_ = resp
 	resp, err = rm.sdkapi.DeleteRepositoryWithContext(ctx, input)

--- a/templates/hooks/repository/sdk_delete_post_build_request.go.tpl
+++ b/templates/hooks/repository/sdk_delete_post_build_request.go.tpl
@@ -1,0 +1,1 @@
+input.SetForce(GetDeleteForce(&r.ko.ObjectMeta))


### PR DESCRIPTION
Resolves aws-controllers-k8s/community#1798

Description of changes:

- Accept `ecr.services.k8s.aws/force-delete` annotation to override default repo deletion behavior. Force deletion is set to `false` by default as discussed in aws-controllers-k8s/community#1798.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
