### PR TITLE
tests: Ready condition rename for ecr-controller

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2025-09-19T16:57:11Z"
-  build_hash: 6b4211163dcc34776b01da9a18217bac0f4103fd
-  go_version: go1.24.6
-  version: v0.52.0
+  build_date: "2025-09-25T05:25:49Z"
+  build_hash: 9c388d9668ea19d0b1b65566d492c4f67c6e64c8
+  go_version: go1.24.7
+  version: 9c388d9
 api_directory_checksum: 4ec6553b4d5f236283df39b882ff81fe134e095e
 api_version: v1alpha1
 aws_sdk_go_version: v1.38.1

--- a/config/crd/bases/ecr.services.k8s.aws_pullthroughcacherules.yaml
+++ b/config/crd/bases/ecr.services.k8s.aws_pullthroughcacherules.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: pullthroughcacherules.ecr.services.k8s.aws
 spec:
   group: ecr.services.k8s.aws

--- a/config/crd/bases/ecr.services.k8s.aws_repositories.yaml
+++ b/config/crd/bases/ecr.services.k8s.aws_repositories.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: repositories.ecr.services.k8s.aws
 spec:
   group: ecr.services.k8s.aws

--- a/go.mod
+++ b/go.mod
@@ -92,3 +92,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/aws-controllers-k8s/runtime => github.com/gustavodiaz7722/ack-runtime v0.57.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/aws-controllers-k8s/iam-controller v1.5.0 h1:O9AYY5P8eIFircfkjIEwkXwGgfXpGRk6xEn8Qb78BiU=
 github.com/aws-controllers-k8s/iam-controller v1.5.0/go.mod h1:V19V1L0e1Gde8/7Ti0wKugtXU9oK8zaaYDe54TQm94E=
-github.com/aws-controllers-k8s/runtime v0.52.0 h1:Q5UIAn6SSBr60t/DiU/zr6NLBlUuK2AG3yy2ma/9gDU=
-github.com/aws-controllers-k8s/runtime v0.52.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/aws-controllers-k8s/secretsmanager-controller v1.1.0 h1:S+8FLIRMcwzR+Vub86L3GJet/XMCMGHIjVyxnNn0dNI=
 github.com/aws-controllers-k8s/secretsmanager-controller v1.1.0/go.mod h1:Q8+dGg+vmB8FcUftJp+Jwe47V5xVVelYWCzCVuKqxOE=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
@@ -88,6 +86,8 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gustavodiaz7722/ack-runtime v0.57.0 h1:85zJyvdPpzOTaWE0icljJcMRf0qlP0oWdOT05hMZ6Z0=
+github.com/gustavodiaz7722/ack-runtime v0.57.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/itchyny/gojq v0.12.6 h1:VjaFn59Em2wTxDNGcrRkDK9ZHMNa8IksOgL13sLL4d0=
 github.com/itchyny/gojq v0.12.6/go.mod h1:ZHrkfu7A+RbZLy5J1/JKpS4poEqrzItSTGDItqsfP0A=
 github.com/itchyny/timefmt-go v0.1.3 h1:7M3LGVDsqcd0VZH2U+x393obrzZisp7C0uEe921iRkU=

--- a/helm/crds/ecr.services.k8s.aws_pullthroughcacherules.yaml
+++ b/helm/crds/ecr.services.k8s.aws_pullthroughcacherules.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: pullthroughcacherules.ecr.services.k8s.aws
 spec:
   group: ecr.services.k8s.aws

--- a/helm/crds/ecr.services.k8s.aws_repositories.yaml
+++ b/helm/crds/ecr.services.k8s.aws_repositories.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: repositories.ecr.services.k8s.aws
 spec:
   group: ecr.services.k8s.aws

--- a/helm/crds/services.k8s.aws_adoptedresources.yaml
+++ b/helm/crds/services.k8s.aws_adoptedresources.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: adoptedresources.services.k8s.aws
 spec:
   group: services.k8s.aws

--- a/helm/crds/services.k8s.aws_fieldexports.yaml
+++ b/helm/crds/services.k8s.aws_fieldexports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: fieldexports.services.k8s.aws
 spec:
   group: services.k8s.aws

--- a/pkg/resource/pull_through_cache_rule/references.go
+++ b/pkg/resource/pull_through_cache_rule/references.go
@@ -25,6 +25,7 @@ import (
 
 	iamapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	secretsmanagerapitypes "github.com/aws-controllers-k8s/secretsmanager-controller/apis/v1alpha1"
@@ -151,8 +152,9 @@ func getReferencedResourceState_Secret(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"Secret",
 				namespace, name)
@@ -163,14 +165,14 @@ func getReferencedResourceState_Secret(
 			"Secret",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"Secret",
 			namespace, name)
@@ -234,8 +236,9 @@ func getReferencedResourceState_Role(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"Role",
 				namespace, name)
@@ -246,14 +249,14 @@ func getReferencedResourceState_Role(
 			"Role",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"Role",
 			namespace, name)

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@098144245704c500a53a15804b0b33e940bee800
+acktest @ git+https://github.com/gustavodiaz7722/ack-test-infra.git@4a5c296da0fe386eadf95c242591ae4724cd0428


### PR DESCRIPTION
This PR updates controller src and test files to the Ready condition:

- Run code generation 
- Update test infra commit id 
- Replace `ACK.ResourceSynced` → `Ready`
- Replace `assert_synced` → `assert_ready`
- Replace `assert_not_synced` → `assert_not_ready`

Generated by helper script.

_No manual changes were made to the controller source; all changes were made via automated script._