### PR TITLE
Mark Repository and RepositoryCreationTemplate policy fields for semantic comparison

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-05-19T18:42:36Z"
+  build_date: "2026-06-17T20:16:45Z"
   build_hash: e581e886276bd781409a3fb11fa665ea31de17d4
-  go_version: go1.26.3
+  go_version: go1.26.0
   version: v0.59.1
 api_directory_checksum: f3cd0040c6fdc4422d08c01cee0b5aec6fad5478
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.0
 generator_config_info:
-  file_checksum: 777f0463b984593e6c79894e314ca7340d04baf3
+  file_checksum: 352aefc447dbd71fb823b32d609475186cfb10af
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -17,10 +17,12 @@ resources:
           operation: CreateRepository
           path: RepositoryName
       LifecyclePolicy:
+        is_document: true
         from:
           operation: PutLifecyclePolicy
           path: LifecyclePolicyText
       Policy:
+        is_iam_policy: true
         from:
           operation: SetRepositoryPolicy
           path: PolicyText
@@ -110,6 +112,10 @@ resources:
       Prefix:
         is_primary_key: true
         is_immutable: true
+      LifecyclePolicy:
+        is_document: true
+      RepositoryPolicy:
+        is_iam_policy: true
       CustomRoleARN:
         references:
           resource: Role

--- a/generator.yaml
+++ b/generator.yaml
@@ -17,10 +17,12 @@ resources:
           operation: CreateRepository
           path: RepositoryName
       LifecyclePolicy:
+        is_document: true
         from:
           operation: PutLifecyclePolicy
           path: LifecyclePolicyText
       Policy:
+        is_iam_policy: true
         from:
           operation: SetRepositoryPolicy
           path: PolicyText
@@ -110,6 +112,10 @@ resources:
       Prefix:
         is_primary_key: true
         is_immutable: true
+      LifecyclePolicy:
+        is_document: true
+      RepositoryPolicy:
+        is_iam_policy: true
       CustomRoleARN:
         references:
           resource: Role

--- a/pkg/resource/repository/delta.go
+++ b/pkg/resource/repository/delta.go
@@ -89,7 +89,7 @@ func newResourceDelta(
 	if ackcompare.HasNilDifference(a.ko.Spec.LifecyclePolicy, b.ko.Spec.LifecyclePolicy) {
 		delta.Add("Spec.LifecyclePolicy", a.ko.Spec.LifecyclePolicy, b.ko.Spec.LifecyclePolicy)
 	} else if a.ko.Spec.LifecyclePolicy != nil && b.ko.Spec.LifecyclePolicy != nil {
-		if *a.ko.Spec.LifecyclePolicy != *b.ko.Spec.LifecyclePolicy {
+		if equal, err := ackcompare.DocumentEqual(*a.ko.Spec.LifecyclePolicy, *b.ko.Spec.LifecyclePolicy); err != nil || !equal {
 			delta.Add("Spec.LifecyclePolicy", a.ko.Spec.LifecyclePolicy, b.ko.Spec.LifecyclePolicy)
 		}
 	}
@@ -103,7 +103,7 @@ func newResourceDelta(
 	if ackcompare.HasNilDifference(a.ko.Spec.Policy, b.ko.Spec.Policy) {
 		delta.Add("Spec.Policy", a.ko.Spec.Policy, b.ko.Spec.Policy)
 	} else if a.ko.Spec.Policy != nil && b.ko.Spec.Policy != nil {
-		if *a.ko.Spec.Policy != *b.ko.Spec.Policy {
+		if equal, err := ackcompare.IAMPolicyDocumentEqual(*a.ko.Spec.Policy, *b.ko.Spec.Policy); err != nil || !equal {
 			delta.Add("Spec.Policy", a.ko.Spec.Policy, b.ko.Spec.Policy)
 		}
 	}

--- a/pkg/resource/repository_creation_template/delta.go
+++ b/pkg/resource/repository_creation_template/delta.go
@@ -101,7 +101,7 @@ func newResourceDelta(
 	if ackcompare.HasNilDifference(a.ko.Spec.LifecyclePolicy, b.ko.Spec.LifecyclePolicy) {
 		delta.Add("Spec.LifecyclePolicy", a.ko.Spec.LifecyclePolicy, b.ko.Spec.LifecyclePolicy)
 	} else if a.ko.Spec.LifecyclePolicy != nil && b.ko.Spec.LifecyclePolicy != nil {
-		if *a.ko.Spec.LifecyclePolicy != *b.ko.Spec.LifecyclePolicy {
+		if equal, err := ackcompare.DocumentEqual(*a.ko.Spec.LifecyclePolicy, *b.ko.Spec.LifecyclePolicy); err != nil || !equal {
 			delta.Add("Spec.LifecyclePolicy", a.ko.Spec.LifecyclePolicy, b.ko.Spec.LifecyclePolicy)
 		}
 	}
@@ -115,7 +115,7 @@ func newResourceDelta(
 	if ackcompare.HasNilDifference(a.ko.Spec.RepositoryPolicy, b.ko.Spec.RepositoryPolicy) {
 		delta.Add("Spec.RepositoryPolicy", a.ko.Spec.RepositoryPolicy, b.ko.Spec.RepositoryPolicy)
 	} else if a.ko.Spec.RepositoryPolicy != nil && b.ko.Spec.RepositoryPolicy != nil {
-		if *a.ko.Spec.RepositoryPolicy != *b.ko.Spec.RepositoryPolicy {
+		if equal, err := ackcompare.IAMPolicyDocumentEqual(*a.ko.Spec.RepositoryPolicy, *b.ko.Spec.RepositoryPolicy); err != nil || !equal {
 			delta.Add("Spec.RepositoryPolicy", a.ko.Spec.RepositoryPolicy, b.ko.Spec.RepositoryPolicy)
 		}
 	}


### PR DESCRIPTION
## Problem

Several ECR fields contain JSON documents that are compared using raw string equality (`!=`) for delta detection. This causes unnecessary reconciliation loops when AWS returns the JSON with different whitespace or key ordering than what was originally submitted.

Affected fields:
- `Repository.LifecyclePolicy` — JSON lifecycle rules document
- `Repository.Policy` — IAM policy document
- `RepositoryCreationTemplate.LifecyclePolicy` — JSON lifecycle rules document
- `RepositoryCreationTemplate.RepositoryPolicy` — IAM policy document

## Solution

Added appropriate annotations in `generator.yaml`:
- `is_document: true` for lifecycle policy fields (uses `ackcompare.DocumentEqual()` for semantic JSON comparison)
- `is_iam_policy: true` for repository policy fields (uses `ackcompare.IAMPolicyDocumentEqual()` which URL-decodes and performs semantic JSON comparison)

## Changes

- `generator.yaml`: Added `is_document: true` for `Repository.LifecyclePolicy` and `RepositoryCreationTemplate.LifecyclePolicy`; added `is_iam_policy: true` for `Repository.Policy` and `RepositoryCreationTemplate.RepositoryPolicy`
- `pkg/resource/repository/delta.go`: Regenerated — uses `DocumentEqual` and `IAMPolicyDocumentEqual`
- `pkg/resource/repository_creation_template/delta.go`: Regenerated — same

## Testing

- `go build -o bin/controller ./cmd/controller` — compiles cleanly
- Existing E2E tests cover Repository fields:
  - `test_repository_lifecycle_policy` — creates repository with lifecycle policy, removes it
  - `test_repository_policy` — creates repository with IAM policy, removes it
  - `test_repository_create_will_all_fields` — creates with all fields including both policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.